### PR TITLE
Support percentage and auto values

### DIFF
--- a/examples/layout.rs
+++ b/examples/layout.rs
@@ -1,6 +1,6 @@
 extern crate yoga;
 
-use yoga::Node;
+use yoga::{Node, Point, Percent};
 
 fn main() {
 	let mut node = Node::new();
@@ -11,8 +11,8 @@ fn main() {
 	node.insert_child(&mut child, 0);
 	node.insert_child(&mut other_child, 1);
 
-	node.set_margin(yoga::Edge::All, 10.0);
-	node.set_padding(yoga::Edge::Horizontal, 4.0);
+	node.set_margin(yoga::Edge::All, 10.point());
+	node.set_padding(yoga::Edge::Horizontal, 4.point());
 
 	node.calculate_layout(512.0, 512.0, yoga::Direction::LTR);
 


### PR DESCRIPTION
@RoyJacobs

Still not entirely sure what the best way is to represent unit types for things like `Percent` and `Point`.

Options:

```
Width(Point(10.0))
```

or

```
Width(10.point())
```

or if I can somehow have this magically default to the `point` unit:

```
Width(10.0)
```

then that would be ideal. I'm thinking about making the `point()` trait function be called `pt` or `dp` (even though these aren't device pixels...)

Aside from that, I also added support for min/max width and height, as well as flex basis.