### PR TITLE
apply_styles can now take a reference to an iterator, avoiding a copy

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -378,44 +378,48 @@ impl Node {
 		}
 	}
 
-	pub fn apply_styles(&mut self, styles: Vec<FlexStyle>) {
+	pub fn apply_styles<'a, I>(&mut self, styles: I) where I: IntoIterator<Item=&'a FlexStyle> {
+		for style in styles {
+			self.apply_style(style);
+		}
+	}
+
+	pub fn apply_style(&mut self, style: &FlexStyle) {
 		use FlexStyle::*;
 
-		for style in styles {
-			match style {
-				AlignItems(align) => self.set_align_items(align),
-				AlignSelf(align) => self.set_align_self(align),
-				BorderBottomWidth(w) => self.set_border(Edge::Bottom, w),
-				BorderLeftWidth(w) => self.set_border(Edge::Left, w),
-				BorderRightWidth(w) => self.set_border(Edge::Right, w),
-				BorderTopWidth(w) => self.set_border(Edge::Top, w),
-				BorderWidth(w) => self.set_border(Edge::All, w),
-				Bottom(b) => self.set_position(Edge::Bottom, b),
-				Flex(f) => self.set_flex(f),
-				FlexDirection(flex_direction) => self.set_flex_direction(flex_direction),
-				FlexWrap(wrap) => self.set_flex_wrap(wrap),
-				Height(h) => self.set_height(h),
-				JustifyContent(justify) => self.set_justify_content(justify),
-				Left(l) => self.set_position(Edge::Left, l),
-				Margin(m) => self.set_margin(Edge::All, m),
-				MarginBottom(m) => self.set_margin(Edge::Bottom, m),
-				MarginHorizontal(m) => self.set_margin(Edge::Horizontal, m),
-				MarginLeft(m) => self.set_margin(Edge::Left, m),
-				MarginRight(m) => self.set_margin(Edge::Right, m),
-				MarginTop(m) => self.set_margin(Edge::Top, m),
-				MarginVertical(m) => self.set_margin(Edge::Vertical, m),
-				Padding(p) => self.set_padding(Edge::All, p),
-				PaddingHorizontal(p) => self.set_padding(Edge::Horizontal, p),
-				PaddingLeft(p) => self.set_padding(Edge::Left, p),
-				PaddingRight(p) => self.set_padding(Edge::Right, p),
-				PaddingTop(p) => self.set_padding(Edge::Top, p),
-				PaddingVertical(p) => self.set_padding(Edge::Vertical, p),
-				Position(position_type) => self.set_position_type(position_type),
-				Right(r) => self.set_position(Edge::Right, r),
-				Start(s) => self.set_position(Edge::Start, s),
-				Top(t) => self.set_position(Edge::Top, t),
-				Width(w) => self.set_width(w)
-			}
+		match *style {
+			AlignItems(align) => self.set_align_items(align),
+			AlignSelf(align) => self.set_align_self(align),
+			BorderBottomWidth(w) => self.set_border(Edge::Bottom, w),
+			BorderLeftWidth(w) => self.set_border(Edge::Left, w),
+			BorderRightWidth(w) => self.set_border(Edge::Right, w),
+			BorderTopWidth(w) => self.set_border(Edge::Top, w),
+			BorderWidth(w) => self.set_border(Edge::All, w),
+			Bottom(b) => self.set_position(Edge::Bottom, b),
+			Flex(f) => self.set_flex(f),
+			FlexDirection(flex_direction) => self.set_flex_direction(flex_direction),
+			FlexWrap(wrap) => self.set_flex_wrap(wrap),
+			Height(h) => self.set_height(h),
+			JustifyContent(justify) => self.set_justify_content(justify),
+			Left(l) => self.set_position(Edge::Left, l),
+			Margin(m) => self.set_margin(Edge::All, m),
+			MarginBottom(m) => self.set_margin(Edge::Bottom, m),
+			MarginHorizontal(m) => self.set_margin(Edge::Horizontal, m),
+			MarginLeft(m) => self.set_margin(Edge::Left, m),
+			MarginRight(m) => self.set_margin(Edge::Right, m),
+			MarginTop(m) => self.set_margin(Edge::Top, m),
+			MarginVertical(m) => self.set_margin(Edge::Vertical, m),
+			Padding(p) => self.set_padding(Edge::All, p),
+			PaddingHorizontal(p) => self.set_padding(Edge::Horizontal, p),
+			PaddingLeft(p) => self.set_padding(Edge::Left, p),
+			PaddingRight(p) => self.set_padding(Edge::Right, p),
+			PaddingTop(p) => self.set_padding(Edge::Top, p),
+			PaddingVertical(p) => self.set_padding(Edge::Vertical, p),
+			Position(position_type) => self.set_position_type(position_type),
+			Right(r) => self.set_position(Edge::Right, r),
+			Start(s) => self.set_position(Edge::Start, s),
+			Top(t) => self.set_position(Edge::Top, t),
+			Width(w) => self.set_width(w)
 		}
 	}
 
@@ -620,14 +624,14 @@ fn test_absolute_layout_width_height_start_top() {
 
 	let mut root = Node::new();
 
-	root.apply_styles(vec!(
+	root.apply_styles(&vec!(
 		Width(100.0),
 		Height(100.0)
 	));
 
 	let mut root_child_0 = Node::new();
 
-	root_child_0.apply_styles(vec!(
+	root_child_0.apply_styles(&vec!(
 		Position(PositionType::Absolute),
 		Start(10.0),
 		Top(10.0),


### PR DESCRIPTION
apply_styles took a "vec", now it can take a reference to any kind of iterable. Also I extracted an "apply_style" which just takes a single style.