### PR TITLE
Add a yoga::prelude module

### DIFF
--- a/examples/layout.rs
+++ b/examples/layout.rs
@@ -1,9 +1,9 @@
 #[macro_use]
 extern crate yoga;
 
-use yoga::{Node, Percent, Point};
-use yoga::FlexStyle::*;
+use yoga::Node;
 use yoga::StyleUnit::{Auto, UndefinedValue};
+use yoga::prelude::*;
 
 fn main() {
 	let mut node = Node::new();
@@ -25,7 +25,8 @@ fn main() {
 	let child_styles = make_styles!(
 		Width(32 pt),
 		Height(32 pt),
-		Margin(Auto)
+		Margin(Auto),
+		FlexGrow(1.0)
 	);
 
 	child.apply_styles(&child_styles);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,11 @@ mod internal {
 use ordered_float::OrderedFloat;
 use std::convert::From;
 
+pub mod prelude {
+	pub use {Percent, Point};
+	pub use FlexStyle::*;
+}
+
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum FlexStyle {
 	AlignContent(Align),
@@ -467,39 +472,39 @@ macro_rules! flex_style {
 	// This way the styles like
 	//     Flex(1.0)
 	// will be converted to:
-	//     Flex(OrderedFloat(1.0))
+	//     Flex(1.0.into())
 	(AspectRatio($val:expr)) => (
-		AspectRatio(OrderedFloat($val))
+		AspectRatio($val.into())
 	);
 	(BorderBottom($val:expr)) => (
-		BorderBottom(OrderedFloat($val))
+		BorderBottom($val.into())
 	);
 	(BorderEnd($val:expr)) => (
-		BorderEnd(OrderedFloat($val))
+		BorderEnd($val.into())
 	);
 	(BorderLeft($val:expr)) => (
-		BorderLeft(OrderedFloat($val))
+		BorderLeft($val.into())
 	);
 	(BorderRight($val:expr)) => (
-		BorderRight(OrderedFloat($val))
+		BorderRight($val.into())
 	);
 	(BorderStart($val:expr)) => (
-		BorderStart(OrderedFloat($val))
+		BorderStart($val.into())
 	);
 	(BorderTop($val:expr)) => (
-		BorderTop(OrderedFloat($val))
+		BorderTop($val.into())
 	);
 	(Border($val:expr)) => (
-		Border(OrderedFloat($val))
+		Border($val.into())
 	);
 	(Flex($val:expr)) => (
-		Flex(OrderedFloat($val))
+		Flex($val.into())
 	);
 	(FlexGrow($val:expr)) => (
-		FlexGrow(OrderedFloat($val))
+		FlexGrow($val.into())
 	);
 	(FlexShrink($val:expr)) => (
-		FlexShrink(OrderedFloat($val))
+		FlexShrink($val.into())
 	);
 	($s:ident($($unit:tt)*)) => (
 		$s(unit!($($unit)*))
@@ -522,7 +527,7 @@ macro_rules! make_styles {
 	( $($s:ident($($unit:tt)*)),* ) => {
 		vec!(
 			$(
-				$s(unit!($($unit)*)),
+				flex_style!($s(unit!($($unit)*))),
 			)*
 		)
 	};
@@ -767,27 +772,35 @@ impl Node {
 	pub fn set_position(&mut self, edge: Edge, position: StyleUnit) {
 		unsafe {
 			match position {
-				StyleUnit::UndefinedValue => internal::YGNodeStyleSetPosition(
-					self.inner_node,
-					internal::YGEdge::from(edge),
-					Undefined,
-				),
-				StyleUnit::Point(val) => internal::YGNodeStyleSetPosition(
-					self.inner_node,
-					internal::YGEdge::from(edge),
-					val.into_inner(),
-				),
-				StyleUnit::Percent(val) => internal::YGNodeStyleSetPositionPercent(
-					self.inner_node,
-					internal::YGEdge::from(edge),
-					val.into_inner(),
-				),
+				StyleUnit::UndefinedValue => {
+					internal::YGNodeStyleSetPosition(
+						self.inner_node,
+						internal::YGEdge::from(edge),
+						Undefined,
+					)
+				}
+				StyleUnit::Point(val) => {
+					internal::YGNodeStyleSetPosition(
+						self.inner_node,
+						internal::YGEdge::from(edge),
+						val.into_inner(),
+					)
+				}
+				StyleUnit::Percent(val) => {
+					internal::YGNodeStyleSetPositionPercent(
+						self.inner_node,
+						internal::YGEdge::from(edge),
+						val.into_inner(),
+					)
+				}
 				// auto is not a valid value for position
-				StyleUnit::Auto => internal::YGNodeStyleSetPosition(
-					self.inner_node,
-					internal::YGEdge::from(edge),
-					Undefined,
-				),
+				StyleUnit::Auto => {
+					internal::YGNodeStyleSetPosition(
+						self.inner_node,
+						internal::YGEdge::from(edge),
+						Undefined,
+					)
+				}
 			}
 		}
 	}
@@ -852,25 +865,33 @@ impl Node {
 	pub fn set_margin(&mut self, edge: Edge, margin: StyleUnit) {
 		unsafe {
 			match margin {
-				StyleUnit::UndefinedValue => internal::YGNodeStyleSetMargin(
-					self.inner_node,
-					internal::YGEdge::from(edge),
-					Undefined,
-				),
-				StyleUnit::Point(val) => internal::YGNodeStyleSetMargin(
-					self.inner_node,
-					internal::YGEdge::from(edge),
-					val.into_inner(),
-				),
-				StyleUnit::Percent(val) => internal::YGNodeStyleSetMarginPercent(
-					self.inner_node,
-					internal::YGEdge::from(edge),
-					val.into_inner(),
-				),
-				StyleUnit::Auto => internal::YGNodeStyleSetMarginAuto(
-					self.inner_node,
-					internal::YGEdge::from(edge),
-				),
+				StyleUnit::UndefinedValue => {
+					internal::YGNodeStyleSetMargin(
+						self.inner_node,
+						internal::YGEdge::from(edge),
+						Undefined,
+					)
+				}
+				StyleUnit::Point(val) => {
+					internal::YGNodeStyleSetMargin(
+						self.inner_node,
+						internal::YGEdge::from(edge),
+						val.into_inner(),
+					)
+				}
+				StyleUnit::Percent(val) => {
+					internal::YGNodeStyleSetMarginPercent(
+						self.inner_node,
+						internal::YGEdge::from(edge),
+						val.into_inner(),
+					)
+				}
+				StyleUnit::Auto => {
+					internal::YGNodeStyleSetMarginAuto(
+						self.inner_node,
+						internal::YGEdge::from(edge),
+					)
+				}
 			}
 		}
 	}
@@ -878,27 +899,35 @@ impl Node {
 	pub fn set_padding(&mut self, edge: Edge, padding: StyleUnit) {
 		unsafe {
 			match padding {
-				StyleUnit::UndefinedValue => internal::YGNodeStyleSetPadding(
-					self.inner_node,
-					internal::YGEdge::from(edge),
-					Undefined,
-				),
-				StyleUnit::Point(val) => internal::YGNodeStyleSetPadding(
-					self.inner_node,
-					internal::YGEdge::from(edge),
-					val.into_inner(),
-				),
-				StyleUnit::Percent(val) => internal::YGNodeStyleSetPaddingPercent(
-					self.inner_node,
-					internal::YGEdge::from(edge),
-					val.into_inner(),
-				),
+				StyleUnit::UndefinedValue => {
+					internal::YGNodeStyleSetPadding(
+						self.inner_node,
+						internal::YGEdge::from(edge),
+						Undefined,
+					)
+				}
+				StyleUnit::Point(val) => {
+					internal::YGNodeStyleSetPadding(
+						self.inner_node,
+						internal::YGEdge::from(edge),
+						val.into_inner(),
+					)
+				}
+				StyleUnit::Percent(val) => {
+					internal::YGNodeStyleSetPaddingPercent(
+						self.inner_node,
+						internal::YGEdge::from(edge),
+						val.into_inner(),
+					)
+				}
 				// auto is not a valid value for padding
-				StyleUnit::Auto => internal::YGNodeStyleSetPadding(
-					self.inner_node,
-					internal::YGEdge::from(edge),
-					Undefined,
-				),
+				StyleUnit::Auto => {
+					internal::YGNodeStyleSetPadding(
+						self.inner_node,
+						internal::YGEdge::from(edge),
+						Undefined,
+					)
+				}
 			}
 		}
 	}
@@ -1456,13 +1485,12 @@ impl Node {
 	}
 }
 
-type InternalMeasureFunc = unsafe extern "C" fn(
-	internal::YGNodeRef,
-	f32,
-	internal::YGMeasureMode,
-	f32,
-	internal::YGMeasureMode,
-) -> internal::YGSize;
+type InternalMeasureFunc = unsafe extern "C" fn(internal::YGNodeRef,
+                                                f32,
+                                                internal::YGMeasureMode,
+                                                f32,
+                                                internal::YGMeasureMode)
+                                                -> internal::YGSize;
 type InternalBaselineFunc = unsafe extern "C" fn(internal::YGNodeRef, f32, f32) -> f32;
 pub type MeasureFunc = Option<extern "C" fn(NodeRef, f32, MeasureMode, f32, MeasureMode) -> Size>;
 pub type BaselineFunc = Option<extern "C" fn(NodeRef, f32, f32) -> f32>;

--- a/tests/absolute_position_test.rs
+++ b/tests/absolute_position_test.rs
@@ -2,10 +2,8 @@ extern crate ordered_float;
 #[macro_use]
 extern crate yoga;
 
-use ordered_float::OrderedFloat;
-use yoga::{Align, Direction, FlexDirection, Justify, Node, Overflow, Percent, Point, PositionType,
-           Undefined, Wrap};
-use yoga::FlexStyle::*;
+use yoga::{Align, Direction, FlexDirection, Justify, Node, Overflow, PositionType, Undefined, Wrap};
+use yoga::prelude::*;
 
 #[test]
 fn test_absolute_layout_width_height_start_top() {

--- a/tests/align_content_test.rs
+++ b/tests/align_content_test.rs
@@ -2,9 +2,8 @@ extern crate ordered_float;
 #[macro_use]
 extern crate yoga;
 
-use ordered_float::OrderedFloat;
-use yoga::{Align, Direction, FlexDirection, Node, Percent, Point, Undefined, Wrap};
-use yoga::FlexStyle::*;
+use yoga::{Align, Direction, FlexDirection, Node, Undefined, Wrap};
+use yoga::prelude::*;
 
 #[test]
 fn test_align_content_flex_start() {

--- a/tests/align_items_test.rs
+++ b/tests/align_items_test.rs
@@ -2,9 +2,8 @@ extern crate ordered_float;
 #[macro_use]
 extern crate yoga;
 
-use ordered_float::OrderedFloat;
-use yoga::{Align, Direction, FlexDirection, Justify, Node, Point, Undefined, Wrap};
-use yoga::FlexStyle::*;
+use yoga::{Align, Direction, FlexDirection, Justify, Node, Undefined, Wrap};
+use yoga::prelude::*;
 
 #[test]
 fn test_align_items_stretch() {

--- a/tests/align_self_test.rs
+++ b/tests/align_self_test.rs
@@ -1,8 +1,8 @@
 #[macro_use]
 extern crate yoga;
 
-use yoga::{Align, Direction, FlexDirection, Node, Point, Undefined};
-use yoga::FlexStyle::*;
+use yoga::{Align, Direction, FlexDirection, Node, Undefined};
+use yoga::prelude::*;
 
 #[test]
 fn test_align_self_center() {

--- a/tests/aspect_ratio_test.rs
+++ b/tests/aspect_ratio_test.rs
@@ -2,10 +2,9 @@ extern crate ordered_float;
 #[macro_use]
 extern crate yoga;
 
-use ordered_float::OrderedFloat;
-use yoga::{Align, Direction, FlexDirection, Justify, MeasureMode, Node, NodeRef, Point,
-           PositionType, Size, Undefined};
-use yoga::FlexStyle::*;
+use yoga::{Align, Direction, FlexDirection, Justify, MeasureMode, Node, NodeRef, PositionType,
+           Size, Undefined};
+use yoga::prelude::*;
 
 #[test]
 fn test_aspect_ratio_cross_defined() {

--- a/tests/baseline_func_test.rs
+++ b/tests/baseline_func_test.rs
@@ -1,8 +1,8 @@
 #[macro_use]
 extern crate yoga;
 
-use yoga::{Align, Direction, FlexDirection, Node, NodeRef, Point, Undefined};
-use yoga::FlexStyle::*;
+use yoga::{Align, Direction, FlexDirection, Node, NodeRef, Undefined};
+use yoga::prelude::*;
 
 #[test]
 fn test_align_baseline_customer_func() {

--- a/tests/border_test.rs
+++ b/tests/border_test.rs
@@ -2,9 +2,8 @@ extern crate ordered_float;
 #[macro_use]
 extern crate yoga;
 
-use ordered_float::OrderedFloat;
-use yoga::{Align, Direction, Justify, Node, Point, Undefined};
-use yoga::FlexStyle::*;
+use yoga::{Align, Direction, Justify, Node, Undefined};
+use yoga::prelude::*;
 
 #[test]
 fn test_border_no_size() {

--- a/tests/computed_margin_test.rs
+++ b/tests/computed_margin_test.rs
@@ -1,8 +1,8 @@
 #[macro_use]
 extern crate yoga;
 
-use yoga::{Direction, Node, Percent, Point};
-use yoga::FlexStyle::*;
+use yoga::{Direction, Node};
+use yoga::prelude::*;
 
 #[test]
 fn test_computed_layout_margin() {

--- a/tests/computed_padding_test.rs
+++ b/tests/computed_padding_test.rs
@@ -1,8 +1,8 @@
 #[macro_use]
 extern crate yoga;
 
-use yoga::{Direction, Node, Percent, Point};
-use yoga::FlexStyle::*;
+use yoga::{Direction, Node};
+use yoga::prelude::*;
 
 #[test]
 fn test_computed_layout_padding() {

--- a/tests/dimension_test.rs
+++ b/tests/dimension_test.rs
@@ -1,8 +1,8 @@
 #[macro_use]
 extern crate yoga;
 
-use yoga::{Direction, Node, Point, Undefined};
-use yoga::FlexStyle::*;
+use yoga::{Direction, Node, Undefined};
+use yoga::prelude::*;
 
 #[test]
 fn test_wrap_child() {

--- a/tests/dirty_marking.rs
+++ b/tests/dirty_marking.rs
@@ -2,9 +2,8 @@ extern crate ordered_float;
 #[macro_use]
 extern crate yoga;
 
-use ordered_float::OrderedFloat;
-use yoga::{Align, Direction, Display, FlexDirection, Node, Point, Undefined};
-use yoga::FlexStyle::*;
+use yoga::{Align, Direction, Display, FlexDirection, Node, Undefined};
+use yoga::prelude::*;
 
 #[test]
 fn test_dirty_propagation() {

--- a/tests/display_test.rs
+++ b/tests/display_test.rs
@@ -2,9 +2,8 @@ extern crate ordered_float;
 #[macro_use]
 extern crate yoga;
 
-use ordered_float::OrderedFloat;
-use yoga::{Direction, Display, FlexDirection, Node, Percent, Point, Undefined};
-use yoga::FlexStyle::*;
+use yoga::{Direction, Display, FlexDirection, Node, Undefined};
+use yoga::prelude::*;
 
 #[test]
 fn test_display_none() {

--- a/tests/edge_test.rs
+++ b/tests/edge_test.rs
@@ -2,9 +2,8 @@ extern crate ordered_float;
 #[macro_use]
 extern crate yoga;
 
-use ordered_float::OrderedFloat;
-use yoga::{Direction, FlexDirection, Node, Point, Undefined};
-use yoga::FlexStyle::*;
+use yoga::{Direction, FlexDirection, Node, Undefined};
+use yoga::prelude::*;
 
 #[test]
 fn test_start_overrides() {

--- a/tests/flex_direction_test.rs
+++ b/tests/flex_direction_test.rs
@@ -1,8 +1,8 @@
 #[macro_use]
 extern crate yoga;
 
-use yoga::{Direction, FlexDirection, Node, Point, Undefined};
-use yoga::FlexStyle::*;
+use yoga::{Direction, FlexDirection, Node, Undefined};
+use yoga::prelude::*;
 
 #[test]
 fn test_flex_direction_column_no_height() {

--- a/tests/flex_test.rs
+++ b/tests/flex_test.rs
@@ -2,9 +2,8 @@ extern crate ordered_float;
 #[macro_use]
 extern crate yoga;
 
-use ordered_float::OrderedFloat;
-use yoga::{Direction, FlexDirection, Node, Point, Undefined};
-use yoga::FlexStyle::*;
+use yoga::{Direction, FlexDirection, Node, Undefined};
+use yoga::prelude::*;
 
 #[test]
 fn test_flex_basis_flex_grow_column() {

--- a/tests/size_overflow_test.rs
+++ b/tests/size_overflow_test.rs
@@ -1,8 +1,8 @@
 #[macro_use]
 extern crate yoga;
 
-use yoga::{Direction, Node, Point, Undefined};
-use yoga::FlexStyle::*;
+use yoga::{Direction, Node, Undefined};
+use yoga::prelude::*;
 
 #[test]
 fn test_nested_overflowing_child() {


### PR DESCRIPTION
* Collect the commonly imported modules into a `yoga::prelude` module
* Change the style macros to expand to `$val.into()` instead of `OrderedFloat($val)` to prevent the need for importing the OrderedFloat crate
* Run rustfmt on the entire src directory