### PR TITLE
Make the `Layout` struct use ordered float to allow eq and hash

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "yoga"
 description = "Rust bindings for Facebook's Yoga, a Flexbox layout engine"
 license = "MIT"
 repository = "https://github.com/bschwind/yoga-rs"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Brian Schwind <brianmschwind@gmail.com>"]
 build = "build.rs"
 

--- a/src/ffi_types/align.rs
+++ b/src/ffi_types/align.rs
@@ -1,0 +1,44 @@
+use internal;
+
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum Align {
+	Auto = 0,
+	FlexStart = 1,
+	Center = 2,
+	FlexEnd = 3,
+	Stretch = 4,
+	Baseline = 5,
+	SpaceBetween = 6,
+	SpaceAround = 7,
+}
+
+impl From<Align> for internal::YGAlign {
+	fn from(a: Align) -> internal::YGAlign {
+		match a {
+			Align::Auto => internal::YGAlign::YGAlignAuto,
+			Align::FlexStart => internal::YGAlign::YGAlignFlexStart,
+			Align::Center => internal::YGAlign::YGAlignCenter,
+			Align::FlexEnd => internal::YGAlign::YGAlignFlexEnd,
+			Align::Stretch => internal::YGAlign::YGAlignStretch,
+			Align::Baseline => internal::YGAlign::YGAlignBaseline,
+			Align::SpaceBetween => internal::YGAlign::YGAlignSpaceBetween,
+			Align::SpaceAround => internal::YGAlign::YGAlignSpaceAround,
+		}
+	}
+}
+
+impl From<internal::YGAlign> for Align {
+	fn from(a: internal::YGAlign) -> Align {
+		match a {
+			internal::YGAlign::YGAlignAuto => Align::Auto,
+			internal::YGAlign::YGAlignFlexStart => Align::FlexStart,
+			internal::YGAlign::YGAlignCenter => Align::Center,
+			internal::YGAlign::YGAlignFlexEnd => Align::FlexEnd,
+			internal::YGAlign::YGAlignStretch => Align::Stretch,
+			internal::YGAlign::YGAlignBaseline => Align::Baseline,
+			internal::YGAlign::YGAlignSpaceBetween => Align::SpaceBetween,
+			internal::YGAlign::YGAlignSpaceAround => Align::SpaceAround,
+		}
+	}
+}

--- a/src/ffi_types/dimension.rs
+++ b/src/ffi_types/dimension.rs
@@ -1,0 +1,17 @@
+use internal;
+
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum Dimension {
+	Width = 0,
+	Height = 1,
+}
+
+impl From<Dimension> for internal::YGDimension {
+	fn from(d: Dimension) -> internal::YGDimension {
+		match d {
+			Dimension::Width => internal::YGDimension::YGDimensionWidth,
+			Dimension::Height => internal::YGDimension::YGDimensionHeight,
+		}
+	}
+}

--- a/src/ffi_types/direction.rs
+++ b/src/ffi_types/direction.rs
@@ -1,0 +1,29 @@
+use internal;
+
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum Direction {
+	Inherit = 0,
+	LTR = 1,
+	RTL = 2,
+}
+
+impl From<Direction> for internal::YGDirection {
+	fn from(d: Direction) -> internal::YGDirection {
+		match d {
+			Direction::Inherit => internal::YGDirection::YGDirectionInherit,
+			Direction::LTR => internal::YGDirection::YGDirectionLTR,
+			Direction::RTL => internal::YGDirection::YGDirectionRTL,
+		}
+	}
+}
+
+impl From<internal::YGDirection> for Direction {
+	fn from(d: internal::YGDirection) -> Direction {
+		match d {
+			internal::YGDirection::YGDirectionInherit => Direction::Inherit,
+			internal::YGDirection::YGDirectionLTR => Direction::LTR,
+			internal::YGDirection::YGDirectionRTL => Direction::RTL,
+		}
+	}
+}

--- a/src/ffi_types/display.rs
+++ b/src/ffi_types/display.rs
@@ -1,0 +1,17 @@
+use internal;
+
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum Display {
+	Flex = 0,
+	None = 1,
+}
+
+impl From<Display> for internal::YGDisplay {
+	fn from(d: Display) -> internal::YGDisplay {
+		match d {
+			Display::Flex => internal::YGDisplay::YGDisplayFlex,
+			Display::None => internal::YGDisplay::YGDisplayNone,
+		}
+	}
+}

--- a/src/ffi_types/edge.rs
+++ b/src/ffi_types/edge.rs
@@ -1,0 +1,31 @@
+use internal;
+
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum Edge {
+	Left = 0,
+	Top = 1,
+	Right = 2,
+	Bottom = 3,
+	Start = 4,
+	End = 5,
+	Horizontal = 6,
+	Vertical = 7,
+	All = 8,
+}
+
+impl From<Edge> for internal::YGEdge {
+	fn from(e: Edge) -> internal::YGEdge {
+		match e {
+			Edge::Left => internal::YGEdge::YGEdgeLeft,
+			Edge::Top => internal::YGEdge::YGEdgeTop,
+			Edge::Right => internal::YGEdge::YGEdgeRight,
+			Edge::Bottom => internal::YGEdge::YGEdgeBottom,
+			Edge::Start => internal::YGEdge::YGEdgeStart,
+			Edge::End => internal::YGEdge::YGEdgeEnd,
+			Edge::Horizontal => internal::YGEdge::YGEdgeHorizontal,
+			Edge::Vertical => internal::YGEdge::YGEdgeVertical,
+			Edge::All => internal::YGEdge::YGEdgeAll,
+		}
+	}
+}

--- a/src/ffi_types/flex_direction.rs
+++ b/src/ffi_types/flex_direction.rs
@@ -1,0 +1,32 @@
+use internal;
+
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum FlexDirection {
+	Column = 0,
+	ColumnReverse = 1,
+	Row = 2,
+	RowReverse = 3,
+}
+
+impl From<FlexDirection> for internal::YGFlexDirection {
+	fn from(f: FlexDirection) -> internal::YGFlexDirection {
+		match f {
+			FlexDirection::Column => internal::YGFlexDirection::YGFlexDirectionColumn,
+			FlexDirection::ColumnReverse => internal::YGFlexDirection::YGFlexDirectionColumnReverse,
+			FlexDirection::Row => internal::YGFlexDirection::YGFlexDirectionRow,
+			FlexDirection::RowReverse => internal::YGFlexDirection::YGFlexDirectionRowReverse,
+		}
+	}
+}
+
+impl From<internal::YGFlexDirection> for FlexDirection {
+	fn from(f: internal::YGFlexDirection) -> FlexDirection {
+		match f {
+			internal::YGFlexDirection::YGFlexDirectionColumn => FlexDirection::Column,
+			internal::YGFlexDirection::YGFlexDirectionColumnReverse => FlexDirection::ColumnReverse,
+			internal::YGFlexDirection::YGFlexDirectionRow => FlexDirection::Row,
+			internal::YGFlexDirection::YGFlexDirectionRowReverse => FlexDirection::RowReverse,
+		}
+	}
+}

--- a/src/ffi_types/justify.rs
+++ b/src/ffi_types/justify.rs
@@ -1,0 +1,35 @@
+use internal;
+
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum Justify {
+	FlexStart = 0,
+	Center = 1,
+	FlexEnd = 2,
+	SpaceBetween = 3,
+	SpaceAround = 4,
+}
+
+impl From<Justify> for internal::YGJustify {
+	fn from(j: Justify) -> internal::YGJustify {
+		match j {
+			Justify::FlexStart => internal::YGJustify::YGJustifyFlexStart,
+			Justify::Center => internal::YGJustify::YGJustifyCenter,
+			Justify::FlexEnd => internal::YGJustify::YGJustifyFlexEnd,
+			Justify::SpaceBetween => internal::YGJustify::YGJustifySpaceBetween,
+			Justify::SpaceAround => internal::YGJustify::YGJustifySpaceAround,
+		}
+	}
+}
+
+impl From<internal::YGJustify> for Justify {
+	fn from(j: internal::YGJustify) -> Justify {
+		match j {
+			internal::YGJustify::YGJustifyFlexStart => Justify::FlexStart,
+			internal::YGJustify::YGJustifyCenter => Justify::Center,
+			internal::YGJustify::YGJustifyFlexEnd => Justify::FlexEnd,
+			internal::YGJustify::YGJustifySpaceBetween => Justify::SpaceBetween,
+			internal::YGJustify::YGJustifySpaceAround => Justify::SpaceAround,
+		}
+	}
+}

--- a/src/ffi_types/log_level.rs
+++ b/src/ffi_types/log_level.rs
@@ -1,0 +1,25 @@
+use internal;
+
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum LogLevel {
+	Error = 0,
+	Warn = 1,
+	Info = 2,
+	Debug = 3,
+	Verbose = 4,
+	Fatal = 5,
+}
+
+impl From<LogLevel> for internal::YGLogLevel {
+	fn from(l: LogLevel) -> internal::YGLogLevel {
+		match l {
+			LogLevel::Error => internal::YGLogLevel::YGLogLevelError,
+			LogLevel::Warn => internal::YGLogLevel::YGLogLevelWarn,
+			LogLevel::Info => internal::YGLogLevel::YGLogLevelInfo,
+			LogLevel::Debug => internal::YGLogLevel::YGLogLevelDebug,
+			LogLevel::Verbose => internal::YGLogLevel::YGLogLevelVerbose,
+			LogLevel::Fatal => internal::YGLogLevel::YGLogLevelFatal,
+		}
+	}
+}

--- a/src/ffi_types/measure_mode.rs
+++ b/src/ffi_types/measure_mode.rs
@@ -1,0 +1,19 @@
+use internal;
+
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum MeasureMode {
+	Undefined = 0,
+	Exactly = 1,
+	AtMost = 2,
+}
+
+impl From<MeasureMode> for internal::YGMeasureMode {
+	fn from(m: MeasureMode) -> internal::YGMeasureMode {
+		match m {
+			MeasureMode::Undefined => internal::YGMeasureMode::YGMeasureModeUndefined,
+			MeasureMode::Exactly => internal::YGMeasureMode::YGMeasureModeExactly,
+			MeasureMode::AtMost => internal::YGMeasureMode::YGMeasureModeAtMost,
+		}
+	}
+}

--- a/src/ffi_types/node_ref.rs
+++ b/src/ffi_types/node_ref.rs
@@ -1,0 +1,3 @@
+use internal;
+
+pub type NodeRef = internal::YGNodeRef;

--- a/src/ffi_types/node_type.rs
+++ b/src/ffi_types/node_type.rs
@@ -1,0 +1,17 @@
+use internal;
+
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum NodeType {
+	Default = 0,
+	Text = 1,
+}
+
+impl From<NodeType> for internal::YGNodeType {
+	fn from(n: NodeType) -> internal::YGNodeType {
+		match n {
+			NodeType::Default => internal::YGNodeType::YGNodeTypeDefault,
+			NodeType::Text => internal::YGNodeType::YGNodeTypeText,
+		}
+	}
+}

--- a/src/ffi_types/overflow.rs
+++ b/src/ffi_types/overflow.rs
@@ -1,0 +1,29 @@
+use internal;
+
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum Overflow {
+	Visible = 0,
+	Hidden = 1,
+	Scroll = 2,
+}
+
+impl From<Overflow> for internal::YGOverflow {
+	fn from(o: Overflow) -> internal::YGOverflow {
+		match o {
+			Overflow::Visible => internal::YGOverflow::YGOverflowVisible,
+			Overflow::Hidden => internal::YGOverflow::YGOverflowHidden,
+			Overflow::Scroll => internal::YGOverflow::YGOverflowScroll,
+		}
+	}
+}
+
+impl From<internal::YGOverflow> for Overflow {
+	fn from(o: internal::YGOverflow) -> Overflow {
+		match o {
+			internal::YGOverflow::YGOverflowVisible => Overflow::Visible,
+			internal::YGOverflow::YGOverflowHidden => Overflow::Hidden,
+			internal::YGOverflow::YGOverflowScroll => Overflow::Scroll,
+		}
+	}
+}

--- a/src/ffi_types/position_type.rs
+++ b/src/ffi_types/position_type.rs
@@ -1,0 +1,26 @@
+use internal;
+
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum PositionType {
+	Relative = 0,
+	Absolute = 1,
+}
+
+impl From<PositionType> for internal::YGPositionType {
+	fn from(p: PositionType) -> internal::YGPositionType {
+		match p {
+			PositionType::Relative => internal::YGPositionType::YGPositionTypeRelative,
+			PositionType::Absolute => internal::YGPositionType::YGPositionTypeAbsolute,
+		}
+	}
+}
+
+impl From<internal::YGPositionType> for PositionType {
+	fn from(p: internal::YGPositionType) -> PositionType {
+		match p {
+			internal::YGPositionType::YGPositionTypeRelative => PositionType::Relative,
+			internal::YGPositionType::YGPositionTypeAbsolute => PositionType::Absolute,
+		}
+	}
+}

--- a/src/ffi_types/print_options.rs
+++ b/src/ffi_types/print_options.rs
@@ -1,0 +1,19 @@
+use internal;
+
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum PrintOptions {
+	Layout = 1,
+	Style = 2,
+	Children = 4,
+}
+
+impl From<PrintOptions> for internal::YGPrintOptions {
+	fn from(p: PrintOptions) -> internal::YGPrintOptions {
+		match p {
+			PrintOptions::Layout => internal::YGPrintOptions::YGPrintOptionsLayout,
+			PrintOptions::Style => internal::YGPrintOptions::YGPrintOptionsStyle,
+			PrintOptions::Children => internal::YGPrintOptions::YGPrintOptionsChildren,
+		}
+	}
+}

--- a/src/ffi_types/size.rs
+++ b/src/ffi_types/size.rs
@@ -1,0 +1,23 @@
+use internal;
+
+#[repr(C)]
+#[derive(Debug, Copy)]
+pub struct Size {
+	pub width: f32,
+	pub height: f32,
+}
+
+impl Clone for Size {
+	fn clone(&self) -> Self {
+		*self
+	}
+}
+
+impl From<Size> for internal::YGSize {
+	fn from(s: Size) -> internal::YGSize {
+		internal::YGSize {
+			width: s.width,
+			height: s.height,
+		}
+	}
+}

--- a/src/ffi_types/size.rs
+++ b/src/ffi_types/size.rs
@@ -1,7 +1,7 @@
 use internal;
 
 #[repr(C)]
-#[derive(Debug, Copy)]
+#[derive(Debug, Copy, PartialEq)]
 pub struct Size {
 	pub width: f32,
 	pub height: f32,

--- a/src/ffi_types/style_unit.rs
+++ b/src/ffi_types/style_unit.rs
@@ -1,0 +1,32 @@
+use internal;
+use ordered_float::OrderedFloat;
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum StyleUnit {
+	UndefinedValue,
+	Point(OrderedFloat<f32>),
+	Percent(OrderedFloat<f32>),
+	Auto,
+}
+
+impl From<StyleUnit> for internal::YGUnit {
+	fn from(s: StyleUnit) -> internal::YGUnit {
+		match s {
+			StyleUnit::UndefinedValue => internal::YGUnit::YGUnitUndefined,
+			StyleUnit::Point(_) => internal::YGUnit::YGUnitPoint,
+			StyleUnit::Percent(_) => internal::YGUnit::YGUnitPercent,
+			StyleUnit::Auto => internal::YGUnit::YGUnitAuto,
+		}
+	}
+}
+
+impl From<internal::YGValue> for StyleUnit {
+	fn from(v: internal::YGValue) -> StyleUnit {
+		match v.unit {
+			internal::YGUnit::YGUnitUndefined => StyleUnit::UndefinedValue,
+			internal::YGUnit::YGUnitPoint => StyleUnit::Point(OrderedFloat(v.value)),
+			internal::YGUnit::YGUnitPercent => StyleUnit::Percent(OrderedFloat(v.value)),
+			internal::YGUnit::YGUnitAuto => StyleUnit::Auto,
+		}
+	}
+}

--- a/src/ffi_types/undefined.rs
+++ b/src/ffi_types/undefined.rs
@@ -1,0 +1,1 @@
+pub use std::f32::NAN as Undefined;

--- a/src/ffi_types/wrap.rs
+++ b/src/ffi_types/wrap.rs
@@ -1,0 +1,29 @@
+use internal;
+
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum Wrap {
+	NoWrap = 0,
+	Wrap = 1,
+	WrapReverse = 2,
+}
+
+impl From<Wrap> for internal::YGWrap {
+	fn from(w: Wrap) -> internal::YGWrap {
+		match w {
+			Wrap::NoWrap => internal::YGWrap::YGWrapNoWrap,
+			Wrap::Wrap => internal::YGWrap::YGWrapWrap,
+			Wrap::WrapReverse => internal::YGWrap::YGWrapWrapReverse,
+		}
+	}
+}
+
+impl From<internal::YGWrap> for Wrap {
+	fn from(w: internal::YGWrap) -> Wrap {
+		match w {
+			internal::YGWrap::YGWrapNoWrap => Wrap::NoWrap,
+			internal::YGWrap::YGWrapWrap => Wrap::Wrap,
+			internal::YGWrap::YGWrapWrapReverse => Wrap::WrapReverse,
+		}
+	}
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -474,14 +474,14 @@ impl Node {
 
 	pub fn get_layout(&self) -> Layout {
 		unsafe {
-			Layout {
-				left: internal::YGNodeLayoutGetLeft(self.inner_node),
-				right: internal::YGNodeLayoutGetRight(self.inner_node),
-				top: internal::YGNodeLayoutGetTop(self.inner_node),
-				bottom: internal::YGNodeLayoutGetBottom(self.inner_node),
-				width: internal::YGNodeLayoutGetWidth(self.inner_node),
-				height: internal::YGNodeLayoutGetHeight(self.inner_node),
-			}
+			Layout::new(
+				internal::YGNodeLayoutGetLeft(self.inner_node),
+				internal::YGNodeLayoutGetRight(self.inner_node),
+				internal::YGNodeLayoutGetTop(self.inner_node),
+				internal::YGNodeLayoutGetBottom(self.inner_node),
+				internal::YGNodeLayoutGetWidth(self.inner_node),
+				internal::YGNodeLayoutGetHeight(self.inner_node),
+			)
 		}
 	}
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,613 +10,40 @@ mod internal {
 	include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 }
 
-use ordered_float::OrderedFloat;
-use std::any::Any;
-use std::convert::From;
-use std::ops::Deref;
-use std::os::raw::c_void;
-
-pub mod prelude {
-	pub use {Percent, Point};
-	pub use FlexStyle::*;
-}
-
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum FlexStyle {
-	AlignContent(Align),
-	AlignItems(Align),
-	AlignSelf(Align),
-	AspectRatio(OrderedFloat<f32>),
-	BorderBottom(OrderedFloat<f32>),
-	BorderEnd(OrderedFloat<f32>),
-	BorderLeft(OrderedFloat<f32>),
-	BorderRight(OrderedFloat<f32>),
-	BorderStart(OrderedFloat<f32>),
-	BorderTop(OrderedFloat<f32>),
-	Border(OrderedFloat<f32>),
-	Bottom(StyleUnit),
-	Display(Display),
-	End(StyleUnit),
-	Flex(OrderedFloat<f32>),
-	FlexBasis(StyleUnit),
-	FlexDirection(FlexDirection),
-	FlexGrow(OrderedFloat<f32>),
-	FlexShrink(OrderedFloat<f32>),
-	FlexWrap(Wrap),
-	Height(StyleUnit),
-	JustifyContent(Justify),
-	Left(StyleUnit),
-	Margin(StyleUnit),
-	MarginBottom(StyleUnit),
-	MarginEnd(StyleUnit),
-	MarginHorizontal(StyleUnit),
-	MarginLeft(StyleUnit),
-	MarginRight(StyleUnit),
-	MarginStart(StyleUnit),
-	MarginTop(StyleUnit),
-	MarginVertical(StyleUnit),
-	MaxHeight(StyleUnit),
-	MaxWidth(StyleUnit),
-	MinHeight(StyleUnit),
-	MinWidth(StyleUnit),
-	Overflow(Overflow),
-	Padding(StyleUnit),
-	PaddingBottom(StyleUnit),
-	PaddingEnd(StyleUnit),
-	PaddingHorizontal(StyleUnit),
-	PaddingLeft(StyleUnit),
-	PaddingRight(StyleUnit),
-	PaddingStart(StyleUnit),
-	PaddingTop(StyleUnit),
-	PaddingVertical(StyleUnit),
-	Position(PositionType),
-	Right(StyleUnit),
-	Start(StyleUnit),
-	Top(StyleUnit),
-	Width(StyleUnit),
-}
-
 // Public re-exports of Yoga enums
-#[repr(u32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum Align {
-	Auto = 0,
-	FlexStart = 1,
-	Center = 2,
-	FlexEnd = 3,
-	Stretch = 4,
-	Baseline = 5,
-	SpaceBetween = 6,
-	SpaceAround = 7,
+mod ffi_types {
+	pub mod align;
+	pub mod dimension;
+	pub mod direction;
+	pub mod display;
+	pub mod edge;
+	pub mod flex_direction;
+	pub mod justify;
+	pub mod log_level;
+	pub mod measure_mode;
+	pub mod node_ref;
+	pub mod node_type;
+	pub mod overflow;
+	pub mod position_type;
+	pub mod print_options;
+	pub mod size;
+	pub mod style_unit;
+	pub mod undefined;
+	pub mod wrap;
 }
 
-impl From<Align> for internal::YGAlign {
-	fn from(a: Align) -> internal::YGAlign {
-		match a {
-			Align::Auto => internal::YGAlign::YGAlignAuto,
-			Align::FlexStart => internal::YGAlign::YGAlignFlexStart,
-			Align::Center => internal::YGAlign::YGAlignCenter,
-			Align::FlexEnd => internal::YGAlign::YGAlignFlexEnd,
-			Align::Stretch => internal::YGAlign::YGAlignStretch,
-			Align::Baseline => internal::YGAlign::YGAlignBaseline,
-			Align::SpaceBetween => internal::YGAlign::YGAlignSpaceBetween,
-			Align::SpaceAround => internal::YGAlign::YGAlignSpaceAround,
-		}
-	}
-}
+pub mod prelude;
+pub mod types;
+pub mod traits;
 
-impl From<internal::YGAlign> for Align {
-	fn from(a: internal::YGAlign) -> Align {
-		match a {
-			internal::YGAlign::YGAlignAuto => Align::Auto,
-			internal::YGAlign::YGAlignFlexStart => Align::FlexStart,
-			internal::YGAlign::YGAlignCenter => Align::Center,
-			internal::YGAlign::YGAlignFlexEnd => Align::FlexEnd,
-			internal::YGAlign::YGAlignStretch => Align::Stretch,
-			internal::YGAlign::YGAlignBaseline => Align::Baseline,
-			internal::YGAlign::YGAlignSpaceBetween => Align::SpaceBetween,
-			internal::YGAlign::YGAlignSpaceAround => Align::SpaceAround,
-		}
-	}
-}
-
-#[repr(u32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum Dimension {
-	Width = 0,
-	Height = 1,
-}
-
-impl From<Dimension> for internal::YGDimension {
-	fn from(d: Dimension) -> internal::YGDimension {
-		match d {
-			Dimension::Width => internal::YGDimension::YGDimensionWidth,
-			Dimension::Height => internal::YGDimension::YGDimensionHeight,
-		}
-	}
-}
-
-#[repr(u32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum Direction {
-	Inherit = 0,
-	LTR = 1,
-	RTL = 2,
-}
-
-impl From<Direction> for internal::YGDirection {
-	fn from(d: Direction) -> internal::YGDirection {
-		match d {
-			Direction::Inherit => internal::YGDirection::YGDirectionInherit,
-			Direction::LTR => internal::YGDirection::YGDirectionLTR,
-			Direction::RTL => internal::YGDirection::YGDirectionRTL,
-		}
-	}
-}
-
-impl From<internal::YGDirection> for Direction {
-	fn from(d: internal::YGDirection) -> Direction {
-		match d {
-			internal::YGDirection::YGDirectionInherit => Direction::Inherit,
-			internal::YGDirection::YGDirectionLTR => Direction::LTR,
-			internal::YGDirection::YGDirectionRTL => Direction::RTL,
-		}
-	}
-}
-
-#[repr(u32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum Display {
-	Flex = 0,
-	None = 1,
-}
-
-impl From<Display> for internal::YGDisplay {
-	fn from(d: Display) -> internal::YGDisplay {
-		match d {
-			Display::Flex => internal::YGDisplay::YGDisplayFlex,
-			Display::None => internal::YGDisplay::YGDisplayNone,
-		}
-	}
-}
-
-#[repr(u32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum Edge {
-	Left = 0,
-	Top = 1,
-	Right = 2,
-	Bottom = 3,
-	Start = 4,
-	End = 5,
-	Horizontal = 6,
-	Vertical = 7,
-	All = 8,
-}
-
-impl From<Edge> for internal::YGEdge {
-	fn from(e: Edge) -> internal::YGEdge {
-		match e {
-			Edge::Left => internal::YGEdge::YGEdgeLeft,
-			Edge::Top => internal::YGEdge::YGEdgeTop,
-			Edge::Right => internal::YGEdge::YGEdgeRight,
-			Edge::Bottom => internal::YGEdge::YGEdgeBottom,
-			Edge::Start => internal::YGEdge::YGEdgeStart,
-			Edge::End => internal::YGEdge::YGEdgeEnd,
-			Edge::Horizontal => internal::YGEdge::YGEdgeHorizontal,
-			Edge::Vertical => internal::YGEdge::YGEdgeVertical,
-			Edge::All => internal::YGEdge::YGEdgeAll,
-		}
-	}
-}
-
-#[repr(u32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum FlexDirection {
-	Column = 0,
-	ColumnReverse = 1,
-	Row = 2,
-	RowReverse = 3,
-}
-
-impl From<FlexDirection> for internal::YGFlexDirection {
-	fn from(f: FlexDirection) -> internal::YGFlexDirection {
-		match f {
-			FlexDirection::Column => internal::YGFlexDirection::YGFlexDirectionColumn,
-			FlexDirection::ColumnReverse => internal::YGFlexDirection::YGFlexDirectionColumnReverse,
-			FlexDirection::Row => internal::YGFlexDirection::YGFlexDirectionRow,
-			FlexDirection::RowReverse => internal::YGFlexDirection::YGFlexDirectionRowReverse,
-		}
-	}
-}
-
-impl From<internal::YGFlexDirection> for FlexDirection {
-	fn from(f: internal::YGFlexDirection) -> FlexDirection {
-		match f {
-			internal::YGFlexDirection::YGFlexDirectionColumn => FlexDirection::Column,
-			internal::YGFlexDirection::YGFlexDirectionColumnReverse => FlexDirection::ColumnReverse,
-			internal::YGFlexDirection::YGFlexDirectionRow => FlexDirection::Row,
-			internal::YGFlexDirection::YGFlexDirectionRowReverse => FlexDirection::RowReverse,
-		}
-	}
-}
-
-#[repr(u32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum Justify {
-	FlexStart = 0,
-	Center = 1,
-	FlexEnd = 2,
-	SpaceBetween = 3,
-	SpaceAround = 4,
-}
-
-impl From<Justify> for internal::YGJustify {
-	fn from(j: Justify) -> internal::YGJustify {
-		match j {
-			Justify::FlexStart => internal::YGJustify::YGJustifyFlexStart,
-			Justify::Center => internal::YGJustify::YGJustifyCenter,
-			Justify::FlexEnd => internal::YGJustify::YGJustifyFlexEnd,
-			Justify::SpaceBetween => internal::YGJustify::YGJustifySpaceBetween,
-			Justify::SpaceAround => internal::YGJustify::YGJustifySpaceAround,
-		}
-	}
-}
-
-impl From<internal::YGJustify> for Justify {
-	fn from(j: internal::YGJustify) -> Justify {
-		match j {
-			internal::YGJustify::YGJustifyFlexStart => Justify::FlexStart,
-			internal::YGJustify::YGJustifyCenter => Justify::Center,
-			internal::YGJustify::YGJustifyFlexEnd => Justify::FlexEnd,
-			internal::YGJustify::YGJustifySpaceBetween => Justify::SpaceBetween,
-			internal::YGJustify::YGJustifySpaceAround => Justify::SpaceAround,
-		}
-	}
-}
-
-#[repr(u32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum LogLevel {
-	Error = 0,
-	Warn = 1,
-	Info = 2,
-	Debug = 3,
-	Verbose = 4,
-	Fatal = 5,
-}
-
-impl From<LogLevel> for internal::YGLogLevel {
-	fn from(l: LogLevel) -> internal::YGLogLevel {
-		match l {
-			LogLevel::Error => internal::YGLogLevel::YGLogLevelError,
-			LogLevel::Warn => internal::YGLogLevel::YGLogLevelWarn,
-			LogLevel::Info => internal::YGLogLevel::YGLogLevelInfo,
-			LogLevel::Debug => internal::YGLogLevel::YGLogLevelDebug,
-			LogLevel::Verbose => internal::YGLogLevel::YGLogLevelVerbose,
-			LogLevel::Fatal => internal::YGLogLevel::YGLogLevelFatal,
-		}
-	}
-}
-
-#[repr(u32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum MeasureMode {
-	Undefined = 0,
-	Exactly = 1,
-	AtMost = 2,
-}
-
-impl From<MeasureMode> for internal::YGMeasureMode {
-	fn from(m: MeasureMode) -> internal::YGMeasureMode {
-		match m {
-			MeasureMode::Undefined => internal::YGMeasureMode::YGMeasureModeUndefined,
-			MeasureMode::Exactly => internal::YGMeasureMode::YGMeasureModeExactly,
-			MeasureMode::AtMost => internal::YGMeasureMode::YGMeasureModeAtMost,
-		}
-	}
-}
-
-#[repr(u32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum NodeType {
-	Default = 0,
-	Text = 1,
-}
-
-impl From<NodeType> for internal::YGNodeType {
-	fn from(n: NodeType) -> internal::YGNodeType {
-		match n {
-			NodeType::Default => internal::YGNodeType::YGNodeTypeDefault,
-			NodeType::Text => internal::YGNodeType::YGNodeTypeText,
-		}
-	}
-}
-
-#[repr(u32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum Overflow {
-	Visible = 0,
-	Hidden = 1,
-	Scroll = 2,
-}
-
-impl From<Overflow> for internal::YGOverflow {
-	fn from(o: Overflow) -> internal::YGOverflow {
-		match o {
-			Overflow::Visible => internal::YGOverflow::YGOverflowVisible,
-			Overflow::Hidden => internal::YGOverflow::YGOverflowHidden,
-			Overflow::Scroll => internal::YGOverflow::YGOverflowScroll,
-		}
-	}
-}
-
-impl From<internal::YGOverflow> for Overflow {
-	fn from(o: internal::YGOverflow) -> Overflow {
-		match o {
-			internal::YGOverflow::YGOverflowVisible => Overflow::Visible,
-			internal::YGOverflow::YGOverflowHidden => Overflow::Hidden,
-			internal::YGOverflow::YGOverflowScroll => Overflow::Scroll,
-		}
-	}
-}
-
-#[repr(u32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum PositionType {
-	Relative = 0,
-	Absolute = 1,
-}
-
-impl From<PositionType> for internal::YGPositionType {
-	fn from(p: PositionType) -> internal::YGPositionType {
-		match p {
-			PositionType::Relative => internal::YGPositionType::YGPositionTypeRelative,
-			PositionType::Absolute => internal::YGPositionType::YGPositionTypeAbsolute,
-		}
-	}
-}
-
-impl From<internal::YGPositionType> for PositionType {
-	fn from(p: internal::YGPositionType) -> PositionType {
-		match p {
-			internal::YGPositionType::YGPositionTypeRelative => PositionType::Relative,
-			internal::YGPositionType::YGPositionTypeAbsolute => PositionType::Absolute,
-		}
-	}
-}
-
-#[repr(u32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum PrintOptions {
-	Layout = 1,
-	Style = 2,
-	Children = 4,
-}
-
-impl From<PrintOptions> for internal::YGPrintOptions {
-	fn from(p: PrintOptions) -> internal::YGPrintOptions {
-		match p {
-			PrintOptions::Layout => internal::YGPrintOptions::YGPrintOptionsLayout,
-			PrintOptions::Style => internal::YGPrintOptions::YGPrintOptionsStyle,
-			PrintOptions::Children => internal::YGPrintOptions::YGPrintOptionsChildren,
-		}
-	}
-}
-
-#[repr(C)]
-#[derive(Debug, Copy)]
-pub struct Size {
-	pub width: f32,
-	pub height: f32,
-}
-
-impl Clone for Size {
-	fn clone(&self) -> Self {
-		*self
-	}
-}
-
-impl From<Size> for internal::YGSize {
-	fn from(s: Size) -> internal::YGSize {
-		internal::YGSize {
-			width: s.width,
-			height: s.height,
-		}
-	}
-}
-
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum StyleUnit {
-	UndefinedValue,
-	Point(OrderedFloat<f32>),
-	Percent(OrderedFloat<f32>),
-	Auto,
-}
-
-impl From<StyleUnit> for internal::YGUnit {
-	fn from(s: StyleUnit) -> internal::YGUnit {
-		match s {
-			StyleUnit::UndefinedValue => internal::YGUnit::YGUnitUndefined,
-			StyleUnit::Point(_) => internal::YGUnit::YGUnitPoint,
-			StyleUnit::Percent(_) => internal::YGUnit::YGUnitPercent,
-			StyleUnit::Auto => internal::YGUnit::YGUnitAuto,
-		}
-	}
-}
-
-impl From<internal::YGValue> for StyleUnit {
-	fn from(v: internal::YGValue) -> StyleUnit {
-		match v.unit {
-			internal::YGUnit::YGUnitUndefined => StyleUnit::UndefinedValue,
-			internal::YGUnit::YGUnitPoint => StyleUnit::Point(OrderedFloat(v.value)),
-			internal::YGUnit::YGUnitPercent => StyleUnit::Percent(OrderedFloat(v.value)),
-			internal::YGUnit::YGUnitAuto => StyleUnit::Auto,
-		}
-	}
-}
-
-#[macro_export]
-macro_rules! unit {
-	( $val:tt pt) => (
-		$val.point()
-	);
-	( $val:tt %) => {
-		$val.percent()
-	};
-	( $val:expr) => {
-		$val
-	};
-}
-
-#[macro_export]
-macro_rules! flex_style {
-	// Manually match on styles which require an OrderedFloat
-	// This way the styles like
-	//     Flex(1.0)
-	// will be converted to:
-	//     Flex(1.0.into())
-	(AspectRatio($val:expr)) => (
-		AspectRatio($val.into())
-	);
-	(BorderBottom($val:expr)) => (
-		BorderBottom($val.into())
-	);
-	(BorderEnd($val:expr)) => (
-		BorderEnd($val.into())
-	);
-	(BorderLeft($val:expr)) => (
-		BorderLeft($val.into())
-	);
-	(BorderRight($val:expr)) => (
-		BorderRight($val.into())
-	);
-	(BorderStart($val:expr)) => (
-		BorderStart($val.into())
-	);
-	(BorderTop($val:expr)) => (
-		BorderTop($val.into())
-	);
-	(Border($val:expr)) => (
-		Border($val.into())
-	);
-	(Flex($val:expr)) => (
-		Flex($val.into())
-	);
-	(FlexGrow($val:expr)) => (
-		FlexGrow($val.into())
-	);
-	(FlexShrink($val:expr)) => (
-		FlexShrink($val.into())
-	);
-	($s:ident($($unit:tt)*)) => (
-		$s(unit!($($unit)*))
-	);
-}
-
-#[macro_export]
-macro_rules! style {
-	( $x:expr, $($s:ident($($unit:tt)*)),* ) => {
-		$x.apply_styles(&vec!(
-			$(
-				flex_style!($s(unit!($($unit)*))),
-			)*
-		))
-	};
-}
-
-#[macro_export]
-macro_rules! make_styles {
-	( $($s:ident($($unit:tt)*)),* ) => {
-		vec!(
-			$(
-				flex_style!($s(unit!($($unit)*))),
-			)*
-		)
-	};
-}
-
-pub trait Percent {
-	fn percent(self) -> StyleUnit;
-}
-
-impl Percent for f32 {
-	fn percent(self) -> StyleUnit {
-		StyleUnit::Percent(OrderedFloat(self))
-	}
-}
-
-impl Percent for i32 {
-	fn percent(self) -> StyleUnit {
-		StyleUnit::Percent(OrderedFloat(self as f32))
-	}
-}
-
-pub trait Point {
-	fn point(self) -> StyleUnit;
-}
-
-impl Point for f32 {
-	fn point(self) -> StyleUnit {
-		StyleUnit::Point(OrderedFloat(self))
-	}
-}
-
-impl Point for i32 {
-	fn point(self) -> StyleUnit {
-		StyleUnit::Point(OrderedFloat(self as f32))
-	}
-}
-
-#[repr(u32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum Wrap {
-	NoWrap = 0,
-	Wrap = 1,
-	WrapReverse = 2,
-}
-
-impl From<Wrap> for internal::YGWrap {
-	fn from(w: Wrap) -> internal::YGWrap {
-		match w {
-			Wrap::NoWrap => internal::YGWrap::YGWrapNoWrap,
-			Wrap::Wrap => internal::YGWrap::YGWrapWrap,
-			Wrap::WrapReverse => internal::YGWrap::YGWrapWrapReverse,
-		}
-	}
-}
-
-impl From<internal::YGWrap> for Wrap {
-	fn from(w: internal::YGWrap) -> Wrap {
-		match w {
-			internal::YGWrap::YGWrapNoWrap => Wrap::NoWrap,
-			internal::YGWrap::YGWrapWrap => Wrap::Wrap,
-			internal::YGWrap::YGWrapWrapReverse => Wrap::WrapReverse,
-		}
-	}
-}
-
-pub use std::f32::NAN as Undefined;
-
-// Custom Rust API
+use std::os::raw::c_void;
+pub use types::*;
 
 #[repr(C)]
 #[derive(Debug, PartialEq, Eq, Hash)]
 pub struct Node {
 	inner_node: NodeRef,
 	should_free: bool,
-}
-
-pub type NodeRef = internal::YGNodeRef;
-
-#[derive(Debug, PartialEq)]
-pub struct Layout {
-	pub left: f32,
-	pub right: f32,
-	pub top: f32,
-	pub bottom: f32,
-	pub width: f32,
-	pub height: f32,
 }
 
 impl Node {
@@ -1442,7 +869,14 @@ impl Node {
 	pub fn set_measure_func(&mut self, func: MeasureFunc) {
 		match func {
 			Some(f) => unsafe {
-				let casted_func: InternalMeasureFunc = std::mem::transmute(f as usize);
+				type Callback = unsafe extern "C" fn(
+					internal::YGNodeRef,
+					f32,
+					internal::YGMeasureMode,
+					f32,
+					internal::YGMeasureMode,
+				) -> internal::YGSize;
+				let casted_func: Callback = std::mem::transmute(f as usize);
 				internal::YGNodeSetMeasureFunc(self.inner_node, Some(casted_func));
 			},
 			None => unsafe {
@@ -1454,7 +888,8 @@ impl Node {
 	pub fn set_baseline_func(&mut self, func: BaselineFunc) {
 		match func {
 			Some(f) => unsafe {
-				let casted_func: InternalBaselineFunc = std::mem::transmute(f as usize);
+				type Callback = unsafe extern "C" fn(internal::YGNodeRef, f32, f32) -> f32;
+				let casted_func: Callback = std::mem::transmute(f as usize);
 				internal::YGNodeSetBaselineFunc(self.inner_node, Some(casted_func));
 			},
 			None => unsafe {
@@ -1476,27 +911,6 @@ impl Node {
 		Node::get_context(&self.inner_node)
 	}
 }
-
-#[derive(Debug)]
-pub struct Context(pub Box<Any>);
-
-impl Deref for Context {
-	type Target = Box<Any>;
-	fn deref(&self) -> &Box<Any> {
-		&self.0
-	}
-}
-
-type InternalMeasureFunc = unsafe extern "C" fn(
-	internal::YGNodeRef,
-	f32,
-	internal::YGMeasureMode,
-	f32,
-	internal::YGMeasureMode,
-) -> internal::YGSize;
-type InternalBaselineFunc = unsafe extern "C" fn(internal::YGNodeRef, f32, f32) -> f32;
-pub type MeasureFunc = Option<extern "C" fn(NodeRef, f32, MeasureMode, f32, MeasureMode) -> Size>;
-pub type BaselineFunc = Option<extern "C" fn(NodeRef, f32, f32) -> f32>;
 
 impl Drop for Node {
 	fn drop(&mut self) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -772,35 +772,27 @@ impl Node {
 	pub fn set_position(&mut self, edge: Edge, position: StyleUnit) {
 		unsafe {
 			match position {
-				StyleUnit::UndefinedValue => {
-					internal::YGNodeStyleSetPosition(
-						self.inner_node,
-						internal::YGEdge::from(edge),
-						Undefined,
-					)
-				}
-				StyleUnit::Point(val) => {
-					internal::YGNodeStyleSetPosition(
-						self.inner_node,
-						internal::YGEdge::from(edge),
-						val.into_inner(),
-					)
-				}
-				StyleUnit::Percent(val) => {
-					internal::YGNodeStyleSetPositionPercent(
-						self.inner_node,
-						internal::YGEdge::from(edge),
-						val.into_inner(),
-					)
-				}
+				StyleUnit::UndefinedValue => internal::YGNodeStyleSetPosition(
+					self.inner_node,
+					internal::YGEdge::from(edge),
+					Undefined,
+				),
+				StyleUnit::Point(val) => internal::YGNodeStyleSetPosition(
+					self.inner_node,
+					internal::YGEdge::from(edge),
+					val.into_inner(),
+				),
+				StyleUnit::Percent(val) => internal::YGNodeStyleSetPositionPercent(
+					self.inner_node,
+					internal::YGEdge::from(edge),
+					val.into_inner(),
+				),
 				// auto is not a valid value for position
-				StyleUnit::Auto => {
-					internal::YGNodeStyleSetPosition(
-						self.inner_node,
-						internal::YGEdge::from(edge),
-						Undefined,
-					)
-				}
+				StyleUnit::Auto => internal::YGNodeStyleSetPosition(
+					self.inner_node,
+					internal::YGEdge::from(edge),
+					Undefined,
+				),
 			}
 		}
 	}
@@ -865,33 +857,25 @@ impl Node {
 	pub fn set_margin(&mut self, edge: Edge, margin: StyleUnit) {
 		unsafe {
 			match margin {
-				StyleUnit::UndefinedValue => {
-					internal::YGNodeStyleSetMargin(
-						self.inner_node,
-						internal::YGEdge::from(edge),
-						Undefined,
-					)
-				}
-				StyleUnit::Point(val) => {
-					internal::YGNodeStyleSetMargin(
-						self.inner_node,
-						internal::YGEdge::from(edge),
-						val.into_inner(),
-					)
-				}
-				StyleUnit::Percent(val) => {
-					internal::YGNodeStyleSetMarginPercent(
-						self.inner_node,
-						internal::YGEdge::from(edge),
-						val.into_inner(),
-					)
-				}
-				StyleUnit::Auto => {
-					internal::YGNodeStyleSetMarginAuto(
-						self.inner_node,
-						internal::YGEdge::from(edge),
-					)
-				}
+				StyleUnit::UndefinedValue => internal::YGNodeStyleSetMargin(
+					self.inner_node,
+					internal::YGEdge::from(edge),
+					Undefined,
+				),
+				StyleUnit::Point(val) => internal::YGNodeStyleSetMargin(
+					self.inner_node,
+					internal::YGEdge::from(edge),
+					val.into_inner(),
+				),
+				StyleUnit::Percent(val) => internal::YGNodeStyleSetMarginPercent(
+					self.inner_node,
+					internal::YGEdge::from(edge),
+					val.into_inner(),
+				),
+				StyleUnit::Auto => internal::YGNodeStyleSetMarginAuto(
+					self.inner_node,
+					internal::YGEdge::from(edge),
+				),
 			}
 		}
 	}
@@ -899,35 +883,27 @@ impl Node {
 	pub fn set_padding(&mut self, edge: Edge, padding: StyleUnit) {
 		unsafe {
 			match padding {
-				StyleUnit::UndefinedValue => {
-					internal::YGNodeStyleSetPadding(
-						self.inner_node,
-						internal::YGEdge::from(edge),
-						Undefined,
-					)
-				}
-				StyleUnit::Point(val) => {
-					internal::YGNodeStyleSetPadding(
-						self.inner_node,
-						internal::YGEdge::from(edge),
-						val.into_inner(),
-					)
-				}
-				StyleUnit::Percent(val) => {
-					internal::YGNodeStyleSetPaddingPercent(
-						self.inner_node,
-						internal::YGEdge::from(edge),
-						val.into_inner(),
-					)
-				}
+				StyleUnit::UndefinedValue => internal::YGNodeStyleSetPadding(
+					self.inner_node,
+					internal::YGEdge::from(edge),
+					Undefined,
+				),
+				StyleUnit::Point(val) => internal::YGNodeStyleSetPadding(
+					self.inner_node,
+					internal::YGEdge::from(edge),
+					val.into_inner(),
+				),
+				StyleUnit::Percent(val) => internal::YGNodeStyleSetPaddingPercent(
+					self.inner_node,
+					internal::YGEdge::from(edge),
+					val.into_inner(),
+				),
 				// auto is not a valid value for padding
-				StyleUnit::Auto => {
-					internal::YGNodeStyleSetPadding(
-						self.inner_node,
-						internal::YGEdge::from(edge),
-						Undefined,
-					)
-				}
+				StyleUnit::Auto => internal::YGNodeStyleSetPadding(
+					self.inner_node,
+					internal::YGEdge::from(edge),
+					Undefined,
+				),
 			}
 		}
 	}
@@ -1485,12 +1461,13 @@ impl Node {
 	}
 }
 
-type InternalMeasureFunc = unsafe extern "C" fn(internal::YGNodeRef,
-                                                f32,
-                                                internal::YGMeasureMode,
-                                                f32,
-                                                internal::YGMeasureMode)
-                                                -> internal::YGSize;
+type InternalMeasureFunc = unsafe extern "C" fn(
+	internal::YGNodeRef,
+	f32,
+	internal::YGMeasureMode,
+	f32,
+	internal::YGMeasureMode,
+) -> internal::YGSize;
 type InternalBaselineFunc = unsafe extern "C" fn(internal::YGNodeRef, f32, f32) -> f32;
 pub type MeasureFunc = Option<extern "C" fn(NodeRef, f32, MeasureMode, f32, MeasureMode) -> Size>;
 pub type BaselineFunc = Option<extern "C" fn(NodeRef, f32, f32) -> f32>;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,0 +1,3 @@
+pub use FlexStyle::*;
+pub use traits::Percent;
+pub use traits::Point;

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,0 +1,34 @@
+use ordered_float::OrderedFloat;
+use types::StyleUnit;
+
+pub trait Percent {
+	fn percent(self) -> StyleUnit;
+}
+
+impl Percent for f32 {
+	fn percent(self) -> StyleUnit {
+		StyleUnit::Percent(OrderedFloat(self))
+	}
+}
+
+impl Percent for i32 {
+	fn percent(self) -> StyleUnit {
+		StyleUnit::Percent(OrderedFloat(self as f32))
+	}
+}
+
+pub trait Point {
+	fn point(self) -> StyleUnit;
+}
+
+impl Point for f32 {
+	fn point(self) -> StyleUnit {
+		StyleUnit::Point(OrderedFloat(self))
+	}
+}
+
+impl Point for i32 {
+	fn point(self) -> StyleUnit {
+		StyleUnit::Point(OrderedFloat(self as f32))
+	}
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -90,7 +90,13 @@ pub struct Layout {
 }
 
 #[derive(Debug)]
-pub struct Context(pub Box<Any>);
+pub struct Context(Box<Any>);
+
+impl Context {
+	pub fn new<T: Any>(value: T) -> Context {
+		Context(Box::new(value))
+	}
+}
 
 impl Deref for Context {
 	type Target = Box<Any>;

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,0 +1,180 @@
+pub use ffi_types::align::*;
+pub use ffi_types::dimension::*;
+pub use ffi_types::direction::*;
+pub use ffi_types::display::*;
+pub use ffi_types::edge::*;
+pub use ffi_types::flex_direction::*;
+pub use ffi_types::justify::*;
+pub use ffi_types::log_level::*;
+pub use ffi_types::measure_mode::*;
+pub use ffi_types::node_ref::*;
+pub use ffi_types::node_type::*;
+pub use ffi_types::overflow::*;
+pub use ffi_types::position_type::*;
+pub use ffi_types::print_options::*;
+pub use ffi_types::size::*;
+pub use ffi_types::style_unit::*;
+pub use ffi_types::undefined::*;
+pub use ffi_types::wrap::*;
+
+use ordered_float::OrderedFloat;
+use std::any::Any;
+use std::ops::Deref;
+
+pub type BaselineFunc = Option<extern "C" fn(NodeRef, f32, f32) -> f32>;
+pub type MeasureFunc = Option<extern "C" fn(NodeRef, f32, MeasureMode, f32, MeasureMode) -> Size>;
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum FlexStyle {
+	AlignContent(Align),
+	AlignItems(Align),
+	AlignSelf(Align),
+	AspectRatio(OrderedFloat<f32>),
+	BorderBottom(OrderedFloat<f32>),
+	BorderEnd(OrderedFloat<f32>),
+	BorderLeft(OrderedFloat<f32>),
+	BorderRight(OrderedFloat<f32>),
+	BorderStart(OrderedFloat<f32>),
+	BorderTop(OrderedFloat<f32>),
+	Border(OrderedFloat<f32>),
+	Bottom(StyleUnit),
+	Display(Display),
+	End(StyleUnit),
+	Flex(OrderedFloat<f32>),
+	FlexBasis(StyleUnit),
+	FlexDirection(FlexDirection),
+	FlexGrow(OrderedFloat<f32>),
+	FlexShrink(OrderedFloat<f32>),
+	FlexWrap(Wrap),
+	Height(StyleUnit),
+	JustifyContent(Justify),
+	Left(StyleUnit),
+	Margin(StyleUnit),
+	MarginBottom(StyleUnit),
+	MarginEnd(StyleUnit),
+	MarginHorizontal(StyleUnit),
+	MarginLeft(StyleUnit),
+	MarginRight(StyleUnit),
+	MarginStart(StyleUnit),
+	MarginTop(StyleUnit),
+	MarginVertical(StyleUnit),
+	MaxHeight(StyleUnit),
+	MaxWidth(StyleUnit),
+	MinHeight(StyleUnit),
+	MinWidth(StyleUnit),
+	Overflow(Overflow),
+	Padding(StyleUnit),
+	PaddingBottom(StyleUnit),
+	PaddingEnd(StyleUnit),
+	PaddingHorizontal(StyleUnit),
+	PaddingLeft(StyleUnit),
+	PaddingRight(StyleUnit),
+	PaddingStart(StyleUnit),
+	PaddingTop(StyleUnit),
+	PaddingVertical(StyleUnit),
+	Position(PositionType),
+	Right(StyleUnit),
+	Start(StyleUnit),
+	Top(StyleUnit),
+	Width(StyleUnit),
+}
+
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub struct Layout {
+	pub left: f32,
+	pub right: f32,
+	pub top: f32,
+	pub bottom: f32,
+	pub width: f32,
+	pub height: f32,
+}
+
+#[derive(Debug)]
+pub struct Context(pub Box<Any>);
+
+impl Deref for Context {
+	type Target = Box<Any>;
+	fn deref(&self) -> &Box<Any> {
+		&self.0
+	}
+}
+
+#[macro_export]
+macro_rules! unit {
+	( $val:tt pt) => (
+		$val.point()
+	);
+	( $val:tt %) => {
+		$val.percent()
+	};
+	( $val:expr) => {
+		$val
+	};
+}
+
+#[macro_export]
+macro_rules! flex_style {
+	// Manually match on styles which require an OrderedFloat
+	// This way the styles like
+	//     Flex(1.0)
+	// will be converted to:
+	//     Flex(1.0.into())
+	(AspectRatio($val:expr)) => (
+		AspectRatio($val.into())
+	);
+	(BorderBottom($val:expr)) => (
+		BorderBottom($val.into())
+	);
+	(BorderEnd($val:expr)) => (
+		BorderEnd($val.into())
+	);
+	(BorderLeft($val:expr)) => (
+		BorderLeft($val.into())
+	);
+	(BorderRight($val:expr)) => (
+		BorderRight($val.into())
+	);
+	(BorderStart($val:expr)) => (
+		BorderStart($val.into())
+	);
+	(BorderTop($val:expr)) => (
+		BorderTop($val.into())
+	);
+	(Border($val:expr)) => (
+		Border($val.into())
+	);
+	(Flex($val:expr)) => (
+		Flex($val.into())
+	);
+	(FlexGrow($val:expr)) => (
+		FlexGrow($val.into())
+	);
+	(FlexShrink($val:expr)) => (
+		FlexShrink($val.into())
+	);
+	($s:ident($($unit:tt)*)) => (
+		$s(unit!($($unit)*))
+	);
+}
+
+#[macro_export]
+macro_rules! style {
+	( $x:expr, $($s:tt($($unit:tt)*)),* ) => {
+		$x.apply_styles(&vec!(
+			$(
+				flex_style!($s(unit!($($unit)*))),
+			)*
+		))
+	};
+}
+
+#[macro_export]
+macro_rules! make_styles {
+	( $($s:tt($($unit:tt)*)),* ) => {
+		vec!(
+			$(
+				flex_style!($s(unit!($($unit)*))),
+			)*
+		)
+	};
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -79,14 +79,51 @@ pub enum FlexStyle {
 	Width(StyleUnit),
 }
 
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct Layout {
-	pub left: f32,
-	pub right: f32,
-	pub top: f32,
-	pub bottom: f32,
-	pub width: f32,
-	pub height: f32,
+	left: OrderedFloat<f32>,
+	right: OrderedFloat<f32>,
+	top: OrderedFloat<f32>,
+	bottom: OrderedFloat<f32>,
+	width: OrderedFloat<f32>,
+	height: OrderedFloat<f32>,
+}
+
+impl Layout {
+	pub fn new(left: f32, right: f32, top: f32, bottom: f32, width: f32, height: f32) -> Layout {
+		Layout {
+			left: left.into(),
+			right: right.into(),
+			top: top.into(),
+			bottom: bottom.into(),
+			width: width.into(),
+			height: height.into(),
+		}
+	}
+
+	pub fn left(&self) -> f32 {
+		self.left.into_inner()
+	}
+
+	pub fn right(&self) -> f32 {
+		self.right.into_inner()
+	}
+
+	pub fn top(&self) -> f32 {
+		self.top.into_inner()
+	}
+
+	pub fn bottom(&self) -> f32 {
+		self.bottom.into_inner()
+	}
+
+	pub fn width(&self) -> f32 {
+		self.width.into_inner()
+	}
+
+	pub fn height(&self) -> f32 {
+		self.height.into_inner()
+	}
 }
 
 #[derive(Debug)]

--- a/tests/absolute_position_test.rs
+++ b/tests/absolute_position_test.rs
@@ -30,30 +30,30 @@ fn test_absolute_layout_width_height_start_top() {
 	let root_layout = root.get_layout();
 	let child_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(10.0, child_layout.left);
-	assert_eq!(10.0, child_layout.top);
-	assert_eq!(10.0, child_layout.width);
-	assert_eq!(10.0, child_layout.height);
+	assert_eq!(10.0, child_layout.left());
+	assert_eq!(10.0, child_layout.top());
+	assert_eq!(10.0, child_layout.width());
+	assert_eq!(10.0, child_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
 	let root_layout = root.get_layout();
 	let child_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(80.0, child_layout.left);
-	assert_eq!(10.0, child_layout.top);
-	assert_eq!(10.0, child_layout.width);
-	assert_eq!(10.0, child_layout.height);
+	assert_eq!(80.0, child_layout.left());
+	assert_eq!(10.0, child_layout.top());
+	assert_eq!(10.0, child_layout.width());
+	assert_eq!(10.0, child_layout.height());
 }
 
 #[test]
@@ -81,30 +81,30 @@ fn test_absolute_layout_width_height_end_bottom() {
 	let root_layout = root.get_layout();
 	let child_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(80.0, child_layout.left);
-	assert_eq!(80.0, child_layout.top);
-	assert_eq!(10.0, child_layout.width);
-	assert_eq!(10.0, child_layout.height);
+	assert_eq!(80.0, child_layout.left());
+	assert_eq!(80.0, child_layout.top());
+	assert_eq!(10.0, child_layout.width());
+	assert_eq!(10.0, child_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
 	let root_layout = root.get_layout();
 	let child_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(10.0, child_layout.left);
-	assert_eq!(80.0, child_layout.top);
-	assert_eq!(10.0, child_layout.width);
-	assert_eq!(10.0, child_layout.height);
+	assert_eq!(10.0, child_layout.left());
+	assert_eq!(80.0, child_layout.top());
+	assert_eq!(10.0, child_layout.width());
+	assert_eq!(10.0, child_layout.height());
 }
 
 #[test]
@@ -132,30 +132,30 @@ fn test_absolute_layout_start_top_end_bottom() {
 	let root_layout = root.get_layout();
 	let child_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(10.0, child_layout.left);
-	assert_eq!(10.0, child_layout.top);
-	assert_eq!(80.0, child_layout.width);
-	assert_eq!(80.0, child_layout.height);
+	assert_eq!(10.0, child_layout.left());
+	assert_eq!(10.0, child_layout.top());
+	assert_eq!(80.0, child_layout.width());
+	assert_eq!(80.0, child_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
 	let root_layout = root.get_layout();
 	let child_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(10.0, child_layout.left);
-	assert_eq!(10.0, child_layout.top);
-	assert_eq!(80.0, child_layout.width);
-	assert_eq!(80.0, child_layout.height);
+	assert_eq!(10.0, child_layout.left());
+	assert_eq!(10.0, child_layout.top());
+	assert_eq!(80.0, child_layout.width());
+	assert_eq!(80.0, child_layout.height());
 }
 
 #[test]
@@ -185,30 +185,30 @@ fn test_absolute_layout_width_height_start_top_end_bottom() {
 	let root_layout = root.get_layout();
 	let child_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(10.0, child_layout.left);
-	assert_eq!(10.0, child_layout.top);
-	assert_eq!(10.0, child_layout.width);
-	assert_eq!(10.0, child_layout.height);
+	assert_eq!(10.0, child_layout.left());
+	assert_eq!(10.0, child_layout.top());
+	assert_eq!(10.0, child_layout.width());
+	assert_eq!(10.0, child_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
 	let root_layout = root.get_layout();
 	let child_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(80.0, child_layout.left);
-	assert_eq!(10.0, child_layout.top);
-	assert_eq!(10.0, child_layout.width);
-	assert_eq!(10.0, child_layout.height);
+	assert_eq!(80.0, child_layout.left());
+	assert_eq!(10.0, child_layout.top());
+	assert_eq!(10.0, child_layout.width());
+	assert_eq!(10.0, child_layout.height());
 }
 
 #[test]
@@ -245,20 +245,20 @@ fn test_do_not_clamp_height_of_absolute_node_to_height_of_its_overflow_hidden_pa
 	let child_layout = root_child_0.get_layout();
 	let child_child_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(50.0, root_layout.width);
-	assert_eq!(50.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(50.0, root_layout.width());
+	assert_eq!(50.0, root_layout.height());
 
-	assert_eq!(0.0, child_layout.left);
-	assert_eq!(0.0, child_layout.top);
-	assert_eq!(100.0, child_layout.width);
-	assert_eq!(100.0, child_layout.height);
+	assert_eq!(0.0, child_layout.left());
+	assert_eq!(0.0, child_layout.top());
+	assert_eq!(100.0, child_layout.width());
+	assert_eq!(100.0, child_layout.height());
 
-	assert_eq!(0.0, child_child_layout.left);
-	assert_eq!(0.0, child_child_layout.top);
-	assert_eq!(100.0, child_child_layout.width);
-	assert_eq!(100.0, child_child_layout.height);
+	assert_eq!(0.0, child_child_layout.left());
+	assert_eq!(0.0, child_child_layout.top());
+	assert_eq!(100.0, child_child_layout.width());
+	assert_eq!(100.0, child_child_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
@@ -266,20 +266,20 @@ fn test_do_not_clamp_height_of_absolute_node_to_height_of_its_overflow_hidden_pa
 	let child_layout = root_child_0.get_layout();
 	let child_child_layout = root_child_0_child0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(50.0, root_layout.width);
-	assert_eq!(50.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(50.0, root_layout.width());
+	assert_eq!(50.0, root_layout.height());
 
-	assert_eq!(-50.0, child_layout.left);
-	assert_eq!(0.0, child_layout.top);
-	assert_eq!(100.0, child_layout.width);
-	assert_eq!(100.0, child_layout.height);
+	assert_eq!(-50.0, child_layout.left());
+	assert_eq!(0.0, child_layout.top());
+	assert_eq!(100.0, child_layout.width());
+	assert_eq!(100.0, child_layout.height());
 
-	assert_eq!(0.0, child_child_layout.left);
-	assert_eq!(0.0, child_child_layout.top);
-	assert_eq!(100.0, child_child_layout.width);
-	assert_eq!(100.0, child_child_layout.height);
+	assert_eq!(0.0, child_child_layout.left());
+	assert_eq!(0.0, child_child_layout.top());
+	assert_eq!(100.0, child_child_layout.width());
+	assert_eq!(100.0, child_child_layout.height());
 }
 
 #[test]
@@ -363,30 +363,30 @@ fn test_absolute_layout_within_border() {
 	let child_2_layout = root_child_2.get_layout();
 	let child_3_layout = root_child_3.get_layout();
 
-	assert_eq!(10.0, root_layout.left);
-	assert_eq!(10.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(10.0, root_layout.left());
+	assert_eq!(10.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(10.0, child_0_layout.left);
-	assert_eq!(10.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(50.0, child_0_layout.height);
+	assert_eq!(10.0, child_0_layout.left());
+	assert_eq!(10.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(50.0, child_0_layout.height());
 
-	assert_eq!(40.0, child_1_layout.left);
-	assert_eq!(40.0, child_1_layout.top);
-	assert_eq!(50.0, child_1_layout.width);
-	assert_eq!(50.0, child_1_layout.height);
+	assert_eq!(40.0, child_1_layout.left());
+	assert_eq!(40.0, child_1_layout.top());
+	assert_eq!(50.0, child_1_layout.width());
+	assert_eq!(50.0, child_1_layout.height());
 
-	assert_eq!(20.0, child_2_layout.left);
-	assert_eq!(20.0, child_2_layout.top);
-	assert_eq!(50.0, child_2_layout.width);
-	assert_eq!(50.0, child_2_layout.height);
+	assert_eq!(20.0, child_2_layout.left());
+	assert_eq!(20.0, child_2_layout.top());
+	assert_eq!(50.0, child_2_layout.width());
+	assert_eq!(50.0, child_2_layout.height());
 
-	assert_eq!(30.0, child_3_layout.left);
-	assert_eq!(30.0, child_3_layout.top);
-	assert_eq!(50.0, child_3_layout.width);
-	assert_eq!(50.0, child_3_layout.height);
+	assert_eq!(30.0, child_3_layout.left());
+	assert_eq!(30.0, child_3_layout.top());
+	assert_eq!(50.0, child_3_layout.width());
+	assert_eq!(50.0, child_3_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
@@ -396,30 +396,30 @@ fn test_absolute_layout_within_border() {
 	let child_2_layout = root_child_2.get_layout();
 	let child_3_layout = root_child_3.get_layout();
 
-	assert_eq!(10.0, root_layout.left);
-	assert_eq!(10.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(10.0, root_layout.left());
+	assert_eq!(10.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(10.0, child_0_layout.left);
-	assert_eq!(10.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(50.0, child_0_layout.height);
+	assert_eq!(10.0, child_0_layout.left());
+	assert_eq!(10.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(50.0, child_0_layout.height());
 
-	assert_eq!(40.0, child_1_layout.left);
-	assert_eq!(40.0, child_1_layout.top);
-	assert_eq!(50.0, child_1_layout.width);
-	assert_eq!(50.0, child_1_layout.height);
+	assert_eq!(40.0, child_1_layout.left());
+	assert_eq!(40.0, child_1_layout.top());
+	assert_eq!(50.0, child_1_layout.width());
+	assert_eq!(50.0, child_1_layout.height());
 
-	assert_eq!(20.0, child_2_layout.left);
-	assert_eq!(20.0, child_2_layout.top);
-	assert_eq!(50.0, child_2_layout.width);
-	assert_eq!(50.0, child_2_layout.height);
+	assert_eq!(20.0, child_2_layout.left());
+	assert_eq!(20.0, child_2_layout.top());
+	assert_eq!(50.0, child_2_layout.width());
+	assert_eq!(50.0, child_2_layout.height());
 
-	assert_eq!(30.0, child_3_layout.left);
-	assert_eq!(30.0, child_3_layout.top);
-	assert_eq!(50.0, child_3_layout.width);
-	assert_eq!(50.0, child_3_layout.height);
+	assert_eq!(30.0, child_3_layout.left());
+	assert_eq!(30.0, child_3_layout.top());
+	assert_eq!(50.0, child_3_layout.width());
+	assert_eq!(50.0, child_3_layout.height());
 }
 
 #[test]
@@ -448,30 +448,30 @@ fn test_absolute_layout_align_items_and_justify_content_center() {
 	let root_layout = root.get_layout();
 	let child_0_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(110.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(110.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(25.0, child_0_layout.left);
-	assert_eq!(30.0, child_0_layout.top);
-	assert_eq!(60.0, child_0_layout.width);
-	assert_eq!(40.0, child_0_layout.height);
+	assert_eq!(25.0, child_0_layout.left());
+	assert_eq!(30.0, child_0_layout.top());
+	assert_eq!(60.0, child_0_layout.width());
+	assert_eq!(40.0, child_0_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
 	let root_layout = root.get_layout();
 	let child_0_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(110.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(110.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(25.0, child_0_layout.left);
-	assert_eq!(30.0, child_0_layout.top);
-	assert_eq!(60.0, child_0_layout.width);
-	assert_eq!(40.0, child_0_layout.height);
+	assert_eq!(25.0, child_0_layout.left());
+	assert_eq!(30.0, child_0_layout.top());
+	assert_eq!(60.0, child_0_layout.width());
+	assert_eq!(40.0, child_0_layout.height());
 }
 
 #[test]
@@ -500,30 +500,30 @@ fn test_absolute_layout_align_items_and_justify_content_flex_end() {
 	let root_layout = root.get_layout();
 	let child_0_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(110.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(110.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(50.0, child_0_layout.left);
-	assert_eq!(60.0, child_0_layout.top);
-	assert_eq!(60.0, child_0_layout.width);
-	assert_eq!(40.0, child_0_layout.height);
+	assert_eq!(50.0, child_0_layout.left());
+	assert_eq!(60.0, child_0_layout.top());
+	assert_eq!(60.0, child_0_layout.width());
+	assert_eq!(40.0, child_0_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
 	let root_layout = root.get_layout();
 	let child_0_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(110.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(110.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(60.0, child_0_layout.top);
-	assert_eq!(60.0, child_0_layout.width);
-	assert_eq!(40.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(60.0, child_0_layout.top());
+	assert_eq!(60.0, child_0_layout.width());
+	assert_eq!(40.0, child_0_layout.height());
 }
 
 #[test]
@@ -551,30 +551,30 @@ fn test_absolute_layout_justify_content_center() {
 	let root_layout = root.get_layout();
 	let child_0_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(110.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(110.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(30.0, child_0_layout.top);
-	assert_eq!(60.0, child_0_layout.width);
-	assert_eq!(40.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(30.0, child_0_layout.top());
+	assert_eq!(60.0, child_0_layout.width());
+	assert_eq!(40.0, child_0_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
 	let root_layout = root.get_layout();
 	let child_0_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(110.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(110.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(50.0, child_0_layout.left);
-	assert_eq!(30.0, child_0_layout.top);
-	assert_eq!(60.0, child_0_layout.width);
-	assert_eq!(40.0, child_0_layout.height);
+	assert_eq!(50.0, child_0_layout.left());
+	assert_eq!(30.0, child_0_layout.top());
+	assert_eq!(60.0, child_0_layout.width());
+	assert_eq!(40.0, child_0_layout.height());
 }
 
 #[test]
@@ -602,30 +602,30 @@ fn test_absolute_layout_align_items_center() {
 	let root_layout = root.get_layout();
 	let child_0_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(110.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(110.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(25.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(60.0, child_0_layout.width);
-	assert_eq!(40.0, child_0_layout.height);
+	assert_eq!(25.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(60.0, child_0_layout.width());
+	assert_eq!(40.0, child_0_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
 	let root_layout = root.get_layout();
 	let child_0_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(110.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(110.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(25.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(60.0, child_0_layout.width);
-	assert_eq!(40.0, child_0_layout.height);
+	assert_eq!(25.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(60.0, child_0_layout.width());
+	assert_eq!(40.0, child_0_layout.height());
 }
 
 #[test]
@@ -653,30 +653,30 @@ fn test_absolute_layout_align_items_center_on_child_only() {
 	let root_layout = root.get_layout();
 	let child_0_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(110.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(110.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(25.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(60.0, child_0_layout.width);
-	assert_eq!(40.0, child_0_layout.height);
+	assert_eq!(25.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(60.0, child_0_layout.width());
+	assert_eq!(40.0, child_0_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
 	let root_layout = root.get_layout();
 	let child_0_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(110.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(110.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(25.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(60.0, child_0_layout.width);
-	assert_eq!(40.0, child_0_layout.height);
+	assert_eq!(25.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(60.0, child_0_layout.width());
+	assert_eq!(40.0, child_0_layout.height());
 }
 
 #[test]
@@ -706,30 +706,30 @@ fn test_absolute_layout_align_items_and_justify_content_center_and_top_position(
 	let root_layout = root.get_layout();
 	let child_0_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(110.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(110.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(25.0, child_0_layout.left);
-	assert_eq!(10.0, child_0_layout.top);
-	assert_eq!(60.0, child_0_layout.width);
-	assert_eq!(40.0, child_0_layout.height);
+	assert_eq!(25.0, child_0_layout.left());
+	assert_eq!(10.0, child_0_layout.top());
+	assert_eq!(60.0, child_0_layout.width());
+	assert_eq!(40.0, child_0_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
 	let root_layout = root.get_layout();
 	let child_0_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(110.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(110.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(25.0, child_0_layout.left);
-	assert_eq!(10.0, child_0_layout.top);
-	assert_eq!(60.0, child_0_layout.width);
-	assert_eq!(40.0, child_0_layout.height);
+	assert_eq!(25.0, child_0_layout.left());
+	assert_eq!(10.0, child_0_layout.top());
+	assert_eq!(60.0, child_0_layout.width());
+	assert_eq!(40.0, child_0_layout.height());
 }
 
 #[test]
@@ -759,30 +759,30 @@ fn test_absolute_layout_align_items_and_justify_content_center_and_bottom_positi
 	let root_layout = root.get_layout();
 	let child_0_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(110.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(110.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(25.0, child_0_layout.left);
-	assert_eq!(50.0, child_0_layout.top);
-	assert_eq!(60.0, child_0_layout.width);
-	assert_eq!(40.0, child_0_layout.height);
+	assert_eq!(25.0, child_0_layout.left());
+	assert_eq!(50.0, child_0_layout.top());
+	assert_eq!(60.0, child_0_layout.width());
+	assert_eq!(40.0, child_0_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
 	let root_layout = root.get_layout();
 	let child_0_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(110.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(110.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(25.0, child_0_layout.left);
-	assert_eq!(50.0, child_0_layout.top);
-	assert_eq!(60.0, child_0_layout.width);
-	assert_eq!(40.0, child_0_layout.height);
+	assert_eq!(25.0, child_0_layout.left());
+	assert_eq!(50.0, child_0_layout.top());
+	assert_eq!(60.0, child_0_layout.width());
+	assert_eq!(40.0, child_0_layout.height());
 }
 
 #[test]
@@ -812,30 +812,30 @@ fn test_absolute_layout_align_items_and_justify_content_center_and_left_position
 	let root_layout = root.get_layout();
 	let child_0_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(110.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(110.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(5.0, child_0_layout.left);
-	assert_eq!(30.0, child_0_layout.top);
-	assert_eq!(60.0, child_0_layout.width);
-	assert_eq!(40.0, child_0_layout.height);
+	assert_eq!(5.0, child_0_layout.left());
+	assert_eq!(30.0, child_0_layout.top());
+	assert_eq!(60.0, child_0_layout.width());
+	assert_eq!(40.0, child_0_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
 	let root_layout = root.get_layout();
 	let child_0_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(110.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(110.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(5.0, child_0_layout.left);
-	assert_eq!(30.0, child_0_layout.top);
-	assert_eq!(60.0, child_0_layout.width);
-	assert_eq!(40.0, child_0_layout.height);
+	assert_eq!(5.0, child_0_layout.left());
+	assert_eq!(30.0, child_0_layout.top());
+	assert_eq!(60.0, child_0_layout.width());
+	assert_eq!(40.0, child_0_layout.height());
 }
 
 #[test]
@@ -865,30 +865,30 @@ fn test_absolute_layout_align_items_and_justify_content_center_and_right_positio
 	let root_layout = root.get_layout();
 	let child_0_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(110.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(110.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(45.0, child_0_layout.left);
-	assert_eq!(30.0, child_0_layout.top);
-	assert_eq!(60.0, child_0_layout.width);
-	assert_eq!(40.0, child_0_layout.height);
+	assert_eq!(45.0, child_0_layout.left());
+	assert_eq!(30.0, child_0_layout.top());
+	assert_eq!(60.0, child_0_layout.width());
+	assert_eq!(40.0, child_0_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
 	let root_layout = root.get_layout();
 	let child_0_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(110.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(110.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(45.0, child_0_layout.left);
-	assert_eq!(30.0, child_0_layout.top);
-	assert_eq!(60.0, child_0_layout.width);
-	assert_eq!(40.0, child_0_layout.height);
+	assert_eq!(45.0, child_0_layout.left());
+	assert_eq!(30.0, child_0_layout.top());
+	assert_eq!(60.0, child_0_layout.width());
+	assert_eq!(40.0, child_0_layout.height());
 }
 
 #[test]
@@ -905,19 +905,19 @@ fn test_position_root_with_rtl_should_position_withoutdirection() {
 
 	let root_layout = root.get_layout();
 
-	assert_eq!(72.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(52.0, root_layout.width);
-	assert_eq!(52.0, root_layout.height);
+	assert_eq!(72.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(52.0, root_layout.width());
+	assert_eq!(52.0, root_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
 	let root_layout = root.get_layout();
 
-	assert_eq!(72.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(52.0, root_layout.width);
-	assert_eq!(52.0, root_layout.height);
+	assert_eq!(72.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(52.0, root_layout.width());
+	assert_eq!(52.0, root_layout.height());
 }
 
 #[test]
@@ -966,25 +966,25 @@ fn test_absolute_layout_percentage_bottom_based_on_parent_height() {
 	let child_1_layout = root_child_1.get_layout();
 	let child_2_layout = root_child_2.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(200.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(200.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(100.0, child_0_layout.top);
-	assert_eq!(10.0, child_0_layout.width);
-	assert_eq!(10.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(100.0, child_0_layout.top());
+	assert_eq!(10.0, child_0_layout.width());
+	assert_eq!(10.0, child_0_layout.height());
 
-	assert_eq!(0.0, child_1_layout.left);
-	assert_eq!(90.0, child_1_layout.top);
-	assert_eq!(10.0, child_1_layout.width);
-	assert_eq!(10.0, child_1_layout.height);
+	assert_eq!(0.0, child_1_layout.left());
+	assert_eq!(90.0, child_1_layout.top());
+	assert_eq!(10.0, child_1_layout.width());
+	assert_eq!(10.0, child_1_layout.height());
 
-	assert_eq!(0.0, child_2_layout.left);
-	assert_eq!(20.0, child_2_layout.top);
-	assert_eq!(10.0, child_2_layout.width);
-	assert_eq!(160.0, child_2_layout.height);
+	assert_eq!(0.0, child_2_layout.left());
+	assert_eq!(20.0, child_2_layout.top());
+	assert_eq!(10.0, child_2_layout.width());
+	assert_eq!(160.0, child_2_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
@@ -993,25 +993,25 @@ fn test_absolute_layout_percentage_bottom_based_on_parent_height() {
 	let child_1_layout = root_child_1.get_layout();
 	let child_2_layout = root_child_2.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(200.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(200.0, root_layout.height());
 
-	assert_eq!(90.0, child_0_layout.left);
-	assert_eq!(100.0, child_0_layout.top);
-	assert_eq!(10.0, child_0_layout.width);
-	assert_eq!(10.0, child_0_layout.height);
+	assert_eq!(90.0, child_0_layout.left());
+	assert_eq!(100.0, child_0_layout.top());
+	assert_eq!(10.0, child_0_layout.width());
+	assert_eq!(10.0, child_0_layout.height());
 
-	assert_eq!(90.0, child_1_layout.left);
-	assert_eq!(90.0, child_1_layout.top);
-	assert_eq!(10.0, child_1_layout.width);
-	assert_eq!(10.0, child_1_layout.height);
+	assert_eq!(90.0, child_1_layout.left());
+	assert_eq!(90.0, child_1_layout.top());
+	assert_eq!(10.0, child_1_layout.width());
+	assert_eq!(10.0, child_1_layout.height());
 
-	assert_eq!(90.0, child_2_layout.left);
-	assert_eq!(20.0, child_2_layout.top);
-	assert_eq!(10.0, child_2_layout.width);
-	assert_eq!(160.0, child_2_layout.height);
+	assert_eq!(90.0, child_2_layout.left());
+	assert_eq!(20.0, child_2_layout.top());
+	assert_eq!(10.0, child_2_layout.width());
+	assert_eq!(160.0, child_2_layout.height());
 }
 
 #[test]
@@ -1038,30 +1038,30 @@ fn test_absolute_layout_in_wrap_reverse_column_container() {
 	let root_layout = root.get_layout();
 	let child_0_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(80.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(20.0, child_0_layout.width);
-	assert_eq!(20.0, child_0_layout.height);
+	assert_eq!(80.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(20.0, child_0_layout.width());
+	assert_eq!(20.0, child_0_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
 	let root_layout = root.get_layout();
 	let child_0_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(20.0, child_0_layout.width);
-	assert_eq!(20.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(20.0, child_0_layout.width());
+	assert_eq!(20.0, child_0_layout.height());
 }
 
 #[test]
@@ -1089,30 +1089,30 @@ fn test_absolute_layout_in_wrap_reverse_row_container() {
 	let root_layout = root.get_layout();
 	let child_0_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(80.0, child_0_layout.top);
-	assert_eq!(20.0, child_0_layout.width);
-	assert_eq!(20.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(80.0, child_0_layout.top());
+	assert_eq!(20.0, child_0_layout.width());
+	assert_eq!(20.0, child_0_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
 	let root_layout = root.get_layout();
 	let child_0_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(80.0, child_0_layout.left);
-	assert_eq!(80.0, child_0_layout.top);
-	assert_eq!(20.0, child_0_layout.width);
-	assert_eq!(20.0, child_0_layout.height);
+	assert_eq!(80.0, child_0_layout.left());
+	assert_eq!(80.0, child_0_layout.top());
+	assert_eq!(20.0, child_0_layout.width());
+	assert_eq!(20.0, child_0_layout.height());
 }
 
 #[test]
@@ -1140,30 +1140,30 @@ fn test_absolute_layout_in_wrap_reverse_column_container_flex_end() {
 	let root_layout = root.get_layout();
 	let child_0_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(20.0, child_0_layout.width);
-	assert_eq!(20.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(20.0, child_0_layout.width());
+	assert_eq!(20.0, child_0_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
 	let root_layout = root.get_layout();
 	let child_0_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(80.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(20.0, child_0_layout.width);
-	assert_eq!(20.0, child_0_layout.height);
+	assert_eq!(80.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(20.0, child_0_layout.width());
+	assert_eq!(20.0, child_0_layout.height());
 }
 
 #[test]
@@ -1192,28 +1192,28 @@ fn test_absolute_layout_in_wrap_reverse_row_container_flex_end() {
 	let root_layout = root.get_layout();
 	let child_0_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(20.0, child_0_layout.width);
-	assert_eq!(20.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(20.0, child_0_layout.width());
+	assert_eq!(20.0, child_0_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
 	let root_layout = root.get_layout();
 	let child_0_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(80.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(20.0, child_0_layout.width);
-	assert_eq!(20.0, child_0_layout.height);
+	assert_eq!(80.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(20.0, child_0_layout.width());
+	assert_eq!(20.0, child_0_layout.height());
 }

--- a/tests/align_content_test.rs
+++ b/tests/align_content_test.rs
@@ -65,35 +65,35 @@ fn test_align_content_flex_start() {
 	let child_3_layout = root_child_3.get_layout();
 	let child_4_layout = root_child_4.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(130.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(130.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(10.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(10.0, child_0_layout.height());
 
-	assert_eq!(50.0, child_1_layout.left);
-	assert_eq!(0.0, child_1_layout.top);
-	assert_eq!(50.0, child_1_layout.width);
-	assert_eq!(10.0, child_1_layout.height);
+	assert_eq!(50.0, child_1_layout.left());
+	assert_eq!(0.0, child_1_layout.top());
+	assert_eq!(50.0, child_1_layout.width());
+	assert_eq!(10.0, child_1_layout.height());
 
-	assert_eq!(0.0, child_2_layout.left);
-	assert_eq!(10.0, child_2_layout.top);
-	assert_eq!(50.0, child_2_layout.width);
-	assert_eq!(10.0, child_2_layout.height);
+	assert_eq!(0.0, child_2_layout.left());
+	assert_eq!(10.0, child_2_layout.top());
+	assert_eq!(50.0, child_2_layout.width());
+	assert_eq!(10.0, child_2_layout.height());
 
-	assert_eq!(50.0, child_3_layout.left);
-	assert_eq!(10.0, child_3_layout.top);
-	assert_eq!(50.0, child_3_layout.width);
-	assert_eq!(10.0, child_3_layout.height);
+	assert_eq!(50.0, child_3_layout.left());
+	assert_eq!(10.0, child_3_layout.top());
+	assert_eq!(50.0, child_3_layout.width());
+	assert_eq!(10.0, child_3_layout.height());
 
-	assert_eq!(0.0, child_4_layout.left);
-	assert_eq!(20.0, child_4_layout.top);
-	assert_eq!(50.0, child_4_layout.width);
-	assert_eq!(10.0, child_4_layout.height);
+	assert_eq!(0.0, child_4_layout.left());
+	assert_eq!(20.0, child_4_layout.top());
+	assert_eq!(50.0, child_4_layout.width());
+	assert_eq!(10.0, child_4_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
@@ -104,35 +104,35 @@ fn test_align_content_flex_start() {
 	let child_3_layout = root_child_3.get_layout();
 	let child_4_layout = root_child_4.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(130.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(130.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(80.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(10.0, child_0_layout.height);
+	assert_eq!(80.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(10.0, child_0_layout.height());
 
-	assert_eq!(30.0, child_1_layout.left);
-	assert_eq!(0.0, child_1_layout.top);
-	assert_eq!(50.0, child_1_layout.width);
-	assert_eq!(10.0, child_1_layout.height);
+	assert_eq!(30.0, child_1_layout.left());
+	assert_eq!(0.0, child_1_layout.top());
+	assert_eq!(50.0, child_1_layout.width());
+	assert_eq!(10.0, child_1_layout.height());
 
-	assert_eq!(80.0, child_2_layout.left);
-	assert_eq!(10.0, child_2_layout.top);
-	assert_eq!(50.0, child_2_layout.width);
-	assert_eq!(10.0, child_2_layout.height);
+	assert_eq!(80.0, child_2_layout.left());
+	assert_eq!(10.0, child_2_layout.top());
+	assert_eq!(50.0, child_2_layout.width());
+	assert_eq!(10.0, child_2_layout.height());
 
-	assert_eq!(30.0, child_3_layout.left);
-	assert_eq!(10.0, child_3_layout.top);
-	assert_eq!(50.0, child_3_layout.width);
-	assert_eq!(10.0, child_3_layout.height);
+	assert_eq!(30.0, child_3_layout.left());
+	assert_eq!(10.0, child_3_layout.top());
+	assert_eq!(50.0, child_3_layout.width());
+	assert_eq!(10.0, child_3_layout.height());
 
-	assert_eq!(80.0, child_4_layout.left);
-	assert_eq!(20.0, child_4_layout.top);
-	assert_eq!(50.0, child_4_layout.width);
-	assert_eq!(10.0, child_4_layout.height);
+	assert_eq!(80.0, child_4_layout.left());
+	assert_eq!(20.0, child_4_layout.top());
+	assert_eq!(50.0, child_4_layout.width());
+	assert_eq!(10.0, child_4_layout.height());
 }
 
 #[test]
@@ -191,35 +191,35 @@ fn test_align_content_flex_start_without_height_on_children() {
 	let child_3_layout = root_child_3.get_layout();
 	let child_4_layout = root_child_4.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(0.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(0.0, child_0_layout.height());
 
-	assert_eq!(0.0, child_1_layout.left);
-	assert_eq!(0.0, child_1_layout.top);
-	assert_eq!(50.0, child_1_layout.width);
-	assert_eq!(10.0, child_1_layout.height);
+	assert_eq!(0.0, child_1_layout.left());
+	assert_eq!(0.0, child_1_layout.top());
+	assert_eq!(50.0, child_1_layout.width());
+	assert_eq!(10.0, child_1_layout.height());
 
-	assert_eq!(0.0, child_2_layout.left);
-	assert_eq!(10.0, child_2_layout.top);
-	assert_eq!(50.0, child_2_layout.width);
-	assert_eq!(0.0, child_2_layout.height);
+	assert_eq!(0.0, child_2_layout.left());
+	assert_eq!(10.0, child_2_layout.top());
+	assert_eq!(50.0, child_2_layout.width());
+	assert_eq!(0.0, child_2_layout.height());
 
-	assert_eq!(0.0, child_3_layout.left);
-	assert_eq!(10.0, child_3_layout.top);
-	assert_eq!(50.0, child_3_layout.width);
-	assert_eq!(10.0, child_3_layout.height);
+	assert_eq!(0.0, child_3_layout.left());
+	assert_eq!(10.0, child_3_layout.top());
+	assert_eq!(50.0, child_3_layout.width());
+	assert_eq!(10.0, child_3_layout.height());
 
-	assert_eq!(0.0, child_4_layout.left);
-	assert_eq!(20.0, child_4_layout.top);
-	assert_eq!(50.0, child_4_layout.width);
-	assert_eq!(0.0, child_4_layout.height);
+	assert_eq!(0.0, child_4_layout.left());
+	assert_eq!(20.0, child_4_layout.top());
+	assert_eq!(50.0, child_4_layout.width());
+	assert_eq!(0.0, child_4_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
@@ -230,35 +230,35 @@ fn test_align_content_flex_start_without_height_on_children() {
 	let child_3_layout = root_child_3.get_layout();
 	let child_4_layout = root_child_4.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(50.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(0.0, child_0_layout.height);
+	assert_eq!(50.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(0.0, child_0_layout.height());
 
-	assert_eq!(50.0, child_1_layout.left);
-	assert_eq!(0.0, child_1_layout.top);
-	assert_eq!(50.0, child_1_layout.width);
-	assert_eq!(10.0, child_1_layout.height);
+	assert_eq!(50.0, child_1_layout.left());
+	assert_eq!(0.0, child_1_layout.top());
+	assert_eq!(50.0, child_1_layout.width());
+	assert_eq!(10.0, child_1_layout.height());
 
-	assert_eq!(50.0, child_2_layout.left);
-	assert_eq!(10.0, child_2_layout.top);
-	assert_eq!(50.0, child_2_layout.width);
-	assert_eq!(0.0, child_2_layout.height);
+	assert_eq!(50.0, child_2_layout.left());
+	assert_eq!(10.0, child_2_layout.top());
+	assert_eq!(50.0, child_2_layout.width());
+	assert_eq!(0.0, child_2_layout.height());
 
-	assert_eq!(50.0, child_3_layout.left);
-	assert_eq!(10.0, child_3_layout.top);
-	assert_eq!(50.0, child_3_layout.width);
-	assert_eq!(10.0, child_3_layout.height);
+	assert_eq!(50.0, child_3_layout.left());
+	assert_eq!(10.0, child_3_layout.top());
+	assert_eq!(50.0, child_3_layout.width());
+	assert_eq!(10.0, child_3_layout.height());
 
-	assert_eq!(50.0, child_4_layout.left);
-	assert_eq!(20.0, child_4_layout.top);
-	assert_eq!(50.0, child_4_layout.width);
-	assert_eq!(0.0, child_4_layout.height);
+	assert_eq!(50.0, child_4_layout.left());
+	assert_eq!(20.0, child_4_layout.top());
+	assert_eq!(50.0, child_4_layout.width());
+	assert_eq!(0.0, child_4_layout.height());
 }
 
 #[test]
@@ -323,35 +323,35 @@ fn test_align_content_flex_start_with_flex() {
 	let child_3_layout = root_child_3.get_layout();
 	let child_4_layout = root_child_4.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(120.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(120.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(40.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(40.0, child_0_layout.height());
 
-	assert_eq!(0.0, child_1_layout.left);
-	assert_eq!(40.0, child_1_layout.top);
-	assert_eq!(50.0, child_1_layout.width);
-	assert_eq!(40.0, child_1_layout.height);
+	assert_eq!(0.0, child_1_layout.left());
+	assert_eq!(40.0, child_1_layout.top());
+	assert_eq!(50.0, child_1_layout.width());
+	assert_eq!(40.0, child_1_layout.height());
 
-	assert_eq!(0.0, child_2_layout.left);
-	assert_eq!(80.0, child_2_layout.top);
-	assert_eq!(50.0, child_2_layout.width);
-	assert_eq!(0.0, child_2_layout.height);
+	assert_eq!(0.0, child_2_layout.left());
+	assert_eq!(80.0, child_2_layout.top());
+	assert_eq!(50.0, child_2_layout.width());
+	assert_eq!(0.0, child_2_layout.height());
 
-	assert_eq!(0.0, child_3_layout.left);
-	assert_eq!(80.0, child_3_layout.top);
-	assert_eq!(50.0, child_3_layout.width);
-	assert_eq!(40.0, child_3_layout.height);
+	assert_eq!(0.0, child_3_layout.left());
+	assert_eq!(80.0, child_3_layout.top());
+	assert_eq!(50.0, child_3_layout.width());
+	assert_eq!(40.0, child_3_layout.height());
 
-	assert_eq!(0.0, child_4_layout.left);
-	assert_eq!(120.0, child_4_layout.top);
-	assert_eq!(50.0, child_4_layout.width);
-	assert_eq!(0.0, child_4_layout.height);
+	assert_eq!(0.0, child_4_layout.left());
+	assert_eq!(120.0, child_4_layout.top());
+	assert_eq!(50.0, child_4_layout.width());
+	assert_eq!(0.0, child_4_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
@@ -362,35 +362,35 @@ fn test_align_content_flex_start_with_flex() {
 	let child_3_layout = root_child_3.get_layout();
 	let child_4_layout = root_child_4.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(120.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(120.0, root_layout.height());
 
-	assert_eq!(50.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(40.0, child_0_layout.height);
+	assert_eq!(50.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(40.0, child_0_layout.height());
 
-	assert_eq!(50.0, child_1_layout.left);
-	assert_eq!(40.0, child_1_layout.top);
-	assert_eq!(50.0, child_1_layout.width);
-	assert_eq!(40.0, child_1_layout.height);
+	assert_eq!(50.0, child_1_layout.left());
+	assert_eq!(40.0, child_1_layout.top());
+	assert_eq!(50.0, child_1_layout.width());
+	assert_eq!(40.0, child_1_layout.height());
 
-	assert_eq!(50.0, child_2_layout.left);
-	assert_eq!(80.0, child_2_layout.top);
-	assert_eq!(50.0, child_2_layout.width);
-	assert_eq!(0.0, child_2_layout.height);
+	assert_eq!(50.0, child_2_layout.left());
+	assert_eq!(80.0, child_2_layout.top());
+	assert_eq!(50.0, child_2_layout.width());
+	assert_eq!(0.0, child_2_layout.height());
 
-	assert_eq!(50.0, child_3_layout.left);
-	assert_eq!(80.0, child_3_layout.top);
-	assert_eq!(50.0, child_3_layout.width);
-	assert_eq!(40.0, child_3_layout.height);
+	assert_eq!(50.0, child_3_layout.left());
+	assert_eq!(80.0, child_3_layout.top());
+	assert_eq!(50.0, child_3_layout.width());
+	assert_eq!(40.0, child_3_layout.height());
 
-	assert_eq!(50.0, child_4_layout.left);
-	assert_eq!(120.0, child_4_layout.top);
-	assert_eq!(50.0, child_4_layout.width);
-	assert_eq!(0.0, child_4_layout.height);
+	assert_eq!(50.0, child_4_layout.left());
+	assert_eq!(120.0, child_4_layout.top());
+	assert_eq!(50.0, child_4_layout.width());
+	assert_eq!(0.0, child_4_layout.height());
 }
 
 #[test]
@@ -453,35 +453,35 @@ fn test_align_content_flex_end() {
 	let child_3_layout = root_child_3.get_layout();
 	let child_4_layout = root_child_4.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(10.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(10.0, child_0_layout.height());
 
-	assert_eq!(0.0, child_1_layout.left);
-	assert_eq!(10.0, child_1_layout.top);
-	assert_eq!(50.0, child_1_layout.width);
-	assert_eq!(10.0, child_1_layout.height);
+	assert_eq!(0.0, child_1_layout.left());
+	assert_eq!(10.0, child_1_layout.top());
+	assert_eq!(50.0, child_1_layout.width());
+	assert_eq!(10.0, child_1_layout.height());
 
-	assert_eq!(0.0, child_2_layout.left);
-	assert_eq!(20.0, child_2_layout.top);
-	assert_eq!(50.0, child_2_layout.width);
-	assert_eq!(10.0, child_2_layout.height);
+	assert_eq!(0.0, child_2_layout.left());
+	assert_eq!(20.0, child_2_layout.top());
+	assert_eq!(50.0, child_2_layout.width());
+	assert_eq!(10.0, child_2_layout.height());
 
-	assert_eq!(0.0, child_3_layout.left);
-	assert_eq!(30.0, child_3_layout.top);
-	assert_eq!(50.0, child_3_layout.width);
-	assert_eq!(10.0, child_3_layout.height);
+	assert_eq!(0.0, child_3_layout.left());
+	assert_eq!(30.0, child_3_layout.top());
+	assert_eq!(50.0, child_3_layout.width());
+	assert_eq!(10.0, child_3_layout.height());
 
-	assert_eq!(0.0, child_4_layout.left);
-	assert_eq!(40.0, child_4_layout.top);
-	assert_eq!(50.0, child_4_layout.width);
-	assert_eq!(10.0, child_4_layout.height);
+	assert_eq!(0.0, child_4_layout.left());
+	assert_eq!(40.0, child_4_layout.top());
+	assert_eq!(50.0, child_4_layout.width());
+	assert_eq!(10.0, child_4_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
@@ -492,35 +492,35 @@ fn test_align_content_flex_end() {
 	let child_3_layout = root_child_3.get_layout();
 	let child_4_layout = root_child_4.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(50.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(10.0, child_0_layout.height);
+	assert_eq!(50.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(10.0, child_0_layout.height());
 
-	assert_eq!(50.0, child_1_layout.left);
-	assert_eq!(10.0, child_1_layout.top);
-	assert_eq!(50.0, child_1_layout.width);
-	assert_eq!(10.0, child_1_layout.height);
+	assert_eq!(50.0, child_1_layout.left());
+	assert_eq!(10.0, child_1_layout.top());
+	assert_eq!(50.0, child_1_layout.width());
+	assert_eq!(10.0, child_1_layout.height());
 
-	assert_eq!(50.0, child_2_layout.left);
-	assert_eq!(20.0, child_2_layout.top);
-	assert_eq!(50.0, child_2_layout.width);
-	assert_eq!(10.0, child_2_layout.height);
+	assert_eq!(50.0, child_2_layout.left());
+	assert_eq!(20.0, child_2_layout.top());
+	assert_eq!(50.0, child_2_layout.width());
+	assert_eq!(10.0, child_2_layout.height());
 
-	assert_eq!(50.0, child_3_layout.left);
-	assert_eq!(30.0, child_3_layout.top);
-	assert_eq!(50.0, child_3_layout.width);
-	assert_eq!(10.0, child_3_layout.height);
+	assert_eq!(50.0, child_3_layout.left());
+	assert_eq!(30.0, child_3_layout.top());
+	assert_eq!(50.0, child_3_layout.width());
+	assert_eq!(10.0, child_3_layout.height());
 
-	assert_eq!(50.0, child_4_layout.left);
-	assert_eq!(40.0, child_4_layout.top);
-	assert_eq!(50.0, child_4_layout.width);
-	assert_eq!(10.0, child_4_layout.height);
+	assert_eq!(50.0, child_4_layout.left());
+	assert_eq!(40.0, child_4_layout.top());
+	assert_eq!(50.0, child_4_layout.width());
+	assert_eq!(10.0, child_4_layout.height());
 }
 
 #[test]
@@ -578,35 +578,35 @@ fn test_align_content_stretch() {
 	let child_3_layout = root_child_3.get_layout();
 	let child_4_layout = root_child_4.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(150.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(150.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(0.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(0.0, child_0_layout.height());
 
-	assert_eq!(0.0, child_1_layout.left);
-	assert_eq!(0.0, child_1_layout.top);
-	assert_eq!(50.0, child_1_layout.width);
-	assert_eq!(0.0, child_1_layout.height);
+	assert_eq!(0.0, child_1_layout.left());
+	assert_eq!(0.0, child_1_layout.top());
+	assert_eq!(50.0, child_1_layout.width());
+	assert_eq!(0.0, child_1_layout.height());
 
-	assert_eq!(0.0, child_2_layout.left);
-	assert_eq!(0.0, child_2_layout.top);
-	assert_eq!(50.0, child_2_layout.width);
-	assert_eq!(0.0, child_2_layout.height);
+	assert_eq!(0.0, child_2_layout.left());
+	assert_eq!(0.0, child_2_layout.top());
+	assert_eq!(50.0, child_2_layout.width());
+	assert_eq!(0.0, child_2_layout.height());
 
-	assert_eq!(0.0, child_3_layout.left);
-	assert_eq!(0.0, child_3_layout.top);
-	assert_eq!(50.0, child_3_layout.width);
-	assert_eq!(0.0, child_3_layout.height);
+	assert_eq!(0.0, child_3_layout.left());
+	assert_eq!(0.0, child_3_layout.top());
+	assert_eq!(50.0, child_3_layout.width());
+	assert_eq!(0.0, child_3_layout.height());
 
-	assert_eq!(0.0, child_4_layout.left);
-	assert_eq!(0.0, child_4_layout.top);
-	assert_eq!(50.0, child_4_layout.width);
-	assert_eq!(0.0, child_4_layout.height);
+	assert_eq!(0.0, child_4_layout.left());
+	assert_eq!(0.0, child_4_layout.top());
+	assert_eq!(50.0, child_4_layout.width());
+	assert_eq!(0.0, child_4_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
@@ -617,35 +617,35 @@ fn test_align_content_stretch() {
 	let child_3_layout = root_child_3.get_layout();
 	let child_4_layout = root_child_4.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(150.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(150.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(100.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(0.0, child_0_layout.height);
+	assert_eq!(100.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(0.0, child_0_layout.height());
 
-	assert_eq!(100.0, child_1_layout.left);
-	assert_eq!(0.0, child_1_layout.top);
-	assert_eq!(50.0, child_1_layout.width);
-	assert_eq!(0.0, child_1_layout.height);
+	assert_eq!(100.0, child_1_layout.left());
+	assert_eq!(0.0, child_1_layout.top());
+	assert_eq!(50.0, child_1_layout.width());
+	assert_eq!(0.0, child_1_layout.height());
 
-	assert_eq!(100.0, child_2_layout.left);
-	assert_eq!(0.0, child_2_layout.top);
-	assert_eq!(50.0, child_2_layout.width);
-	assert_eq!(0.0, child_2_layout.height);
+	assert_eq!(100.0, child_2_layout.left());
+	assert_eq!(0.0, child_2_layout.top());
+	assert_eq!(50.0, child_2_layout.width());
+	assert_eq!(0.0, child_2_layout.height());
 
-	assert_eq!(100.0, child_3_layout.left);
-	assert_eq!(0.0, child_3_layout.top);
-	assert_eq!(50.0, child_3_layout.width);
-	assert_eq!(0.0, child_3_layout.height);
+	assert_eq!(100.0, child_3_layout.left());
+	assert_eq!(0.0, child_3_layout.top());
+	assert_eq!(50.0, child_3_layout.width());
+	assert_eq!(0.0, child_3_layout.height());
 
-	assert_eq!(100.0, child_4_layout.left);
-	assert_eq!(0.0, child_4_layout.top);
-	assert_eq!(50.0, child_4_layout.width);
-	assert_eq!(0.0, child_4_layout.height);
+	assert_eq!(100.0, child_4_layout.left());
+	assert_eq!(0.0, child_4_layout.top());
+	assert_eq!(50.0, child_4_layout.width());
+	assert_eq!(0.0, child_4_layout.height());
 }
 
 #[test]
@@ -709,35 +709,35 @@ fn test_align_content_spacebetween() {
 	let child_3_layout = root_child_3.get_layout();
 	let child_4_layout = root_child_4.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(130.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(130.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(10.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(10.0, child_0_layout.height());
 
-	assert_eq!(50.0, child_1_layout.left);
-	assert_eq!(0.0, child_1_layout.top);
-	assert_eq!(50.0, child_1_layout.width);
-	assert_eq!(10.0, child_1_layout.height);
+	assert_eq!(50.0, child_1_layout.left());
+	assert_eq!(0.0, child_1_layout.top());
+	assert_eq!(50.0, child_1_layout.width());
+	assert_eq!(10.0, child_1_layout.height());
 
-	assert_eq!(0.0, child_2_layout.left);
-	assert_eq!(45.0, child_2_layout.top);
-	assert_eq!(50.0, child_2_layout.width);
-	assert_eq!(10.0, child_2_layout.height);
+	assert_eq!(0.0, child_2_layout.left());
+	assert_eq!(45.0, child_2_layout.top());
+	assert_eq!(50.0, child_2_layout.width());
+	assert_eq!(10.0, child_2_layout.height());
 
-	assert_eq!(50.0, child_3_layout.left);
-	assert_eq!(45.0, child_3_layout.top);
-	assert_eq!(50.0, child_3_layout.width);
-	assert_eq!(10.0, child_3_layout.height);
+	assert_eq!(50.0, child_3_layout.left());
+	assert_eq!(45.0, child_3_layout.top());
+	assert_eq!(50.0, child_3_layout.width());
+	assert_eq!(10.0, child_3_layout.height());
 
-	assert_eq!(0.0, child_4_layout.left);
-	assert_eq!(90.0, child_4_layout.top);
-	assert_eq!(50.0, child_4_layout.width);
-	assert_eq!(10.0, child_4_layout.height);
+	assert_eq!(0.0, child_4_layout.left());
+	assert_eq!(90.0, child_4_layout.top());
+	assert_eq!(50.0, child_4_layout.width());
+	assert_eq!(10.0, child_4_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
@@ -748,35 +748,35 @@ fn test_align_content_spacebetween() {
 	let child_3_layout = root_child_3.get_layout();
 	let child_4_layout = root_child_4.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(130.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(130.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(80.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(10.0, child_0_layout.height);
+	assert_eq!(80.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(10.0, child_0_layout.height());
 
-	assert_eq!(30.0, child_1_layout.left);
-	assert_eq!(0.0, child_1_layout.top);
-	assert_eq!(50.0, child_1_layout.width);
-	assert_eq!(10.0, child_1_layout.height);
+	assert_eq!(30.0, child_1_layout.left());
+	assert_eq!(0.0, child_1_layout.top());
+	assert_eq!(50.0, child_1_layout.width());
+	assert_eq!(10.0, child_1_layout.height());
 
-	assert_eq!(80.0, child_2_layout.left);
-	assert_eq!(45.0, child_2_layout.top);
-	assert_eq!(50.0, child_2_layout.width);
-	assert_eq!(10.0, child_2_layout.height);
+	assert_eq!(80.0, child_2_layout.left());
+	assert_eq!(45.0, child_2_layout.top());
+	assert_eq!(50.0, child_2_layout.width());
+	assert_eq!(10.0, child_2_layout.height());
 
-	assert_eq!(30.0, child_3_layout.left);
-	assert_eq!(45.0, child_3_layout.top);
-	assert_eq!(50.0, child_3_layout.width);
-	assert_eq!(10.0, child_3_layout.height);
+	assert_eq!(30.0, child_3_layout.left());
+	assert_eq!(45.0, child_3_layout.top());
+	assert_eq!(50.0, child_3_layout.width());
+	assert_eq!(10.0, child_3_layout.height());
 
-	assert_eq!(80.0, child_4_layout.left);
-	assert_eq!(90.0, child_4_layout.top);
-	assert_eq!(50.0, child_4_layout.width);
-	assert_eq!(10.0, child_4_layout.height);
+	assert_eq!(80.0, child_4_layout.left());
+	assert_eq!(90.0, child_4_layout.top());
+	assert_eq!(50.0, child_4_layout.width());
+	assert_eq!(10.0, child_4_layout.height());
 }
 
 #[test]
@@ -840,35 +840,35 @@ fn test_align_content_spacearound() {
 	let child_3_layout = root_child_3.get_layout();
 	let child_4_layout = root_child_4.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(140.0, root_layout.width);
-	assert_eq!(120.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(140.0, root_layout.width());
+	assert_eq!(120.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(15.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(10.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(15.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(10.0, child_0_layout.height());
 
-	assert_eq!(50.0, child_1_layout.left);
-	assert_eq!(15.0, child_1_layout.top);
-	assert_eq!(50.0, child_1_layout.width);
-	assert_eq!(10.0, child_1_layout.height);
+	assert_eq!(50.0, child_1_layout.left());
+	assert_eq!(15.0, child_1_layout.top());
+	assert_eq!(50.0, child_1_layout.width());
+	assert_eq!(10.0, child_1_layout.height());
 
-	assert_eq!(0.0, child_2_layout.left);
-	assert_eq!(55.0, child_2_layout.top);
-	assert_eq!(50.0, child_2_layout.width);
-	assert_eq!(10.0, child_2_layout.height);
+	assert_eq!(0.0, child_2_layout.left());
+	assert_eq!(55.0, child_2_layout.top());
+	assert_eq!(50.0, child_2_layout.width());
+	assert_eq!(10.0, child_2_layout.height());
 
-	assert_eq!(50.0, child_3_layout.left);
-	assert_eq!(55.0, child_3_layout.top);
-	assert_eq!(50.0, child_3_layout.width);
-	assert_eq!(10.0, child_3_layout.height);
+	assert_eq!(50.0, child_3_layout.left());
+	assert_eq!(55.0, child_3_layout.top());
+	assert_eq!(50.0, child_3_layout.width());
+	assert_eq!(10.0, child_3_layout.height());
 
-	assert_eq!(0.0, child_4_layout.left);
-	assert_eq!(95.0, child_4_layout.top);
-	assert_eq!(50.0, child_4_layout.width);
-	assert_eq!(10.0, child_4_layout.height);
+	assert_eq!(0.0, child_4_layout.left());
+	assert_eq!(95.0, child_4_layout.top());
+	assert_eq!(50.0, child_4_layout.width());
+	assert_eq!(10.0, child_4_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
@@ -879,35 +879,35 @@ fn test_align_content_spacearound() {
 	let child_3_layout = root_child_3.get_layout();
 	let child_4_layout = root_child_4.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(140.0, root_layout.width);
-	assert_eq!(120.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(140.0, root_layout.width());
+	assert_eq!(120.0, root_layout.height());
 
-	assert_eq!(90.0, child_0_layout.left);
-	assert_eq!(15.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(10.0, child_0_layout.height);
+	assert_eq!(90.0, child_0_layout.left());
+	assert_eq!(15.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(10.0, child_0_layout.height());
 
-	assert_eq!(40.0, child_1_layout.left);
-	assert_eq!(15.0, child_1_layout.top);
-	assert_eq!(50.0, child_1_layout.width);
-	assert_eq!(10.0, child_1_layout.height);
+	assert_eq!(40.0, child_1_layout.left());
+	assert_eq!(15.0, child_1_layout.top());
+	assert_eq!(50.0, child_1_layout.width());
+	assert_eq!(10.0, child_1_layout.height());
 
-	assert_eq!(90.0, child_2_layout.left);
-	assert_eq!(55.0, child_2_layout.top);
-	assert_eq!(50.0, child_2_layout.width);
-	assert_eq!(10.0, child_2_layout.height);
+	assert_eq!(90.0, child_2_layout.left());
+	assert_eq!(55.0, child_2_layout.top());
+	assert_eq!(50.0, child_2_layout.width());
+	assert_eq!(10.0, child_2_layout.height());
 
-	assert_eq!(40.0, child_3_layout.left);
-	assert_eq!(55.0, child_3_layout.top);
-	assert_eq!(50.0, child_3_layout.width);
-	assert_eq!(10.0, child_3_layout.height);
+	assert_eq!(40.0, child_3_layout.left());
+	assert_eq!(55.0, child_3_layout.top());
+	assert_eq!(50.0, child_3_layout.width());
+	assert_eq!(10.0, child_3_layout.height());
 
-	assert_eq!(90.0, child_4_layout.left);
-	assert_eq!(95.0, child_4_layout.top);
-	assert_eq!(50.0, child_4_layout.width);
-	assert_eq!(10.0, child_4_layout.height);
+	assert_eq!(90.0, child_4_layout.left());
+	assert_eq!(95.0, child_4_layout.top());
+	assert_eq!(50.0, child_4_layout.width());
+	assert_eq!(10.0, child_4_layout.height());
 }
 
 #[test]
@@ -966,35 +966,35 @@ fn test_align_content_stretch_row() {
 	let child_3_layout = root_child_3.get_layout();
 	let child_4_layout = root_child_4.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(150.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(150.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(50.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(50.0, child_0_layout.height());
 
-	assert_eq!(50.0, child_1_layout.left);
-	assert_eq!(0.0, child_1_layout.top);
-	assert_eq!(50.0, child_1_layout.width);
-	assert_eq!(50.0, child_1_layout.height);
+	assert_eq!(50.0, child_1_layout.left());
+	assert_eq!(0.0, child_1_layout.top());
+	assert_eq!(50.0, child_1_layout.width());
+	assert_eq!(50.0, child_1_layout.height());
 
-	assert_eq!(100.0, child_2_layout.left);
-	assert_eq!(0.0, child_2_layout.top);
-	assert_eq!(50.0, child_2_layout.width);
-	assert_eq!(50.0, child_2_layout.height);
+	assert_eq!(100.0, child_2_layout.left());
+	assert_eq!(0.0, child_2_layout.top());
+	assert_eq!(50.0, child_2_layout.width());
+	assert_eq!(50.0, child_2_layout.height());
 
-	assert_eq!(0.0, child_3_layout.left);
-	assert_eq!(50.0, child_3_layout.top);
-	assert_eq!(50.0, child_3_layout.width);
-	assert_eq!(50.0, child_3_layout.height);
+	assert_eq!(0.0, child_3_layout.left());
+	assert_eq!(50.0, child_3_layout.top());
+	assert_eq!(50.0, child_3_layout.width());
+	assert_eq!(50.0, child_3_layout.height());
 
-	assert_eq!(50.0, child_4_layout.left);
-	assert_eq!(50.0, child_4_layout.top);
-	assert_eq!(50.0, child_4_layout.width);
-	assert_eq!(50.0, child_4_layout.height);
+	assert_eq!(50.0, child_4_layout.left());
+	assert_eq!(50.0, child_4_layout.top());
+	assert_eq!(50.0, child_4_layout.width());
+	assert_eq!(50.0, child_4_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
@@ -1005,35 +1005,35 @@ fn test_align_content_stretch_row() {
 	let child_3_layout = root_child_3.get_layout();
 	let child_4_layout = root_child_4.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(150.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(150.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(100.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(50.0, child_0_layout.height);
+	assert_eq!(100.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(50.0, child_0_layout.height());
 
-	assert_eq!(50.0, child_1_layout.left);
-	assert_eq!(0.0, child_1_layout.top);
-	assert_eq!(50.0, child_1_layout.width);
-	assert_eq!(50.0, child_1_layout.height);
+	assert_eq!(50.0, child_1_layout.left());
+	assert_eq!(0.0, child_1_layout.top());
+	assert_eq!(50.0, child_1_layout.width());
+	assert_eq!(50.0, child_1_layout.height());
 
-	assert_eq!(0.0, child_2_layout.left);
-	assert_eq!(0.0, child_2_layout.top);
-	assert_eq!(50.0, child_2_layout.width);
-	assert_eq!(50.0, child_2_layout.height);
+	assert_eq!(0.0, child_2_layout.left());
+	assert_eq!(0.0, child_2_layout.top());
+	assert_eq!(50.0, child_2_layout.width());
+	assert_eq!(50.0, child_2_layout.height());
 
-	assert_eq!(100.0, child_3_layout.left);
-	assert_eq!(50.0, child_3_layout.top);
-	assert_eq!(50.0, child_3_layout.width);
-	assert_eq!(50.0, child_3_layout.height);
+	assert_eq!(100.0, child_3_layout.left());
+	assert_eq!(50.0, child_3_layout.top());
+	assert_eq!(50.0, child_3_layout.width());
+	assert_eq!(50.0, child_3_layout.height());
 
-	assert_eq!(50.0, child_4_layout.left);
-	assert_eq!(50.0, child_4_layout.top);
-	assert_eq!(50.0, child_4_layout.width);
-	assert_eq!(50.0, child_4_layout.height);
+	assert_eq!(50.0, child_4_layout.left());
+	assert_eq!(50.0, child_4_layout.top());
+	assert_eq!(50.0, child_4_layout.width());
+	assert_eq!(50.0, child_4_layout.height());
 }
 
 #[test]
@@ -1103,40 +1103,40 @@ fn test_align_content_stretch_row_with_children() {
 	let child_3_layout = root_child_3.get_layout();
 	let child_4_layout = root_child_4.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(150.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(150.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(50.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(50.0, child_0_layout.height());
 
-	assert_eq!(0.0, child_0_child_0_layout.left);
-	assert_eq!(0.0, child_0_child_0_layout.top);
-	assert_eq!(50.0, child_0_child_0_layout.width);
-	assert_eq!(50.0, child_0_child_0_layout.height);
+	assert_eq!(0.0, child_0_child_0_layout.left());
+	assert_eq!(0.0, child_0_child_0_layout.top());
+	assert_eq!(50.0, child_0_child_0_layout.width());
+	assert_eq!(50.0, child_0_child_0_layout.height());
 
-	assert_eq!(50.0, child_1_layout.left);
-	assert_eq!(0.0, child_1_layout.top);
-	assert_eq!(50.0, child_1_layout.width);
-	assert_eq!(50.0, child_1_layout.height);
+	assert_eq!(50.0, child_1_layout.left());
+	assert_eq!(0.0, child_1_layout.top());
+	assert_eq!(50.0, child_1_layout.width());
+	assert_eq!(50.0, child_1_layout.height());
 
-	assert_eq!(100.0, child_2_layout.left);
-	assert_eq!(0.0, child_2_layout.top);
-	assert_eq!(50.0, child_2_layout.width);
-	assert_eq!(50.0, child_2_layout.height);
+	assert_eq!(100.0, child_2_layout.left());
+	assert_eq!(0.0, child_2_layout.top());
+	assert_eq!(50.0, child_2_layout.width());
+	assert_eq!(50.0, child_2_layout.height());
 
-	assert_eq!(0.0, child_3_layout.left);
-	assert_eq!(50.0, child_3_layout.top);
-	assert_eq!(50.0, child_3_layout.width);
-	assert_eq!(50.0, child_3_layout.height);
+	assert_eq!(0.0, child_3_layout.left());
+	assert_eq!(50.0, child_3_layout.top());
+	assert_eq!(50.0, child_3_layout.width());
+	assert_eq!(50.0, child_3_layout.height());
 
-	assert_eq!(50.0, child_4_layout.left);
-	assert_eq!(50.0, child_4_layout.top);
-	assert_eq!(50.0, child_4_layout.width);
-	assert_eq!(50.0, child_4_layout.height);
+	assert_eq!(50.0, child_4_layout.left());
+	assert_eq!(50.0, child_4_layout.top());
+	assert_eq!(50.0, child_4_layout.width());
+	assert_eq!(50.0, child_4_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
@@ -1148,40 +1148,40 @@ fn test_align_content_stretch_row_with_children() {
 	let child_3_layout = root_child_3.get_layout();
 	let child_4_layout = root_child_4.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(150.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(150.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(100.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(50.0, child_0_layout.height);
+	assert_eq!(100.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(50.0, child_0_layout.height());
 
-	assert_eq!(0.0, child_0_child_0_layout.left);
-	assert_eq!(0.0, child_0_child_0_layout.top);
-	assert_eq!(50.0, child_0_child_0_layout.width);
-	assert_eq!(50.0, child_0_child_0_layout.height);
+	assert_eq!(0.0, child_0_child_0_layout.left());
+	assert_eq!(0.0, child_0_child_0_layout.top());
+	assert_eq!(50.0, child_0_child_0_layout.width());
+	assert_eq!(50.0, child_0_child_0_layout.height());
 
-	assert_eq!(50.0, child_1_layout.left);
-	assert_eq!(0.0, child_1_layout.top);
-	assert_eq!(50.0, child_1_layout.width);
-	assert_eq!(50.0, child_1_layout.height);
+	assert_eq!(50.0, child_1_layout.left());
+	assert_eq!(0.0, child_1_layout.top());
+	assert_eq!(50.0, child_1_layout.width());
+	assert_eq!(50.0, child_1_layout.height());
 
-	assert_eq!(0.0, child_2_layout.left);
-	assert_eq!(0.0, child_2_layout.top);
-	assert_eq!(50.0, child_2_layout.width);
-	assert_eq!(50.0, child_2_layout.height);
+	assert_eq!(0.0, child_2_layout.left());
+	assert_eq!(0.0, child_2_layout.top());
+	assert_eq!(50.0, child_2_layout.width());
+	assert_eq!(50.0, child_2_layout.height());
 
-	assert_eq!(100.0, child_3_layout.left);
-	assert_eq!(50.0, child_3_layout.top);
-	assert_eq!(50.0, child_3_layout.width);
-	assert_eq!(50.0, child_3_layout.height);
+	assert_eq!(100.0, child_3_layout.left());
+	assert_eq!(50.0, child_3_layout.top());
+	assert_eq!(50.0, child_3_layout.width());
+	assert_eq!(50.0, child_3_layout.height());
 
-	assert_eq!(50.0, child_4_layout.left);
-	assert_eq!(50.0, child_4_layout.top);
-	assert_eq!(50.0, child_4_layout.width);
-	assert_eq!(50.0, child_4_layout.height);
+	assert_eq!(50.0, child_4_layout.left());
+	assert_eq!(50.0, child_4_layout.top());
+	assert_eq!(50.0, child_4_layout.width());
+	assert_eq!(50.0, child_4_layout.height());
 }
 
 #[test]
@@ -1246,35 +1246,35 @@ fn test_align_content_stretch_row_with_flex() {
 	let child_3_layout = root_child_3.get_layout();
 	let child_4_layout = root_child_4.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(150.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(150.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(100.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(100.0, child_0_layout.height());
 
-	assert_eq!(50.0, child_1_layout.left);
-	assert_eq!(0.0, child_1_layout.top);
-	assert_eq!(0.0, child_1_layout.width);
-	assert_eq!(100.0, child_1_layout.height);
+	assert_eq!(50.0, child_1_layout.left());
+	assert_eq!(0.0, child_1_layout.top());
+	assert_eq!(0.0, child_1_layout.width());
+	assert_eq!(100.0, child_1_layout.height());
 
-	assert_eq!(50.0, child_2_layout.left);
-	assert_eq!(0.0, child_2_layout.top);
-	assert_eq!(50.0, child_2_layout.width);
-	assert_eq!(100.0, child_2_layout.height);
+	assert_eq!(50.0, child_2_layout.left());
+	assert_eq!(0.0, child_2_layout.top());
+	assert_eq!(50.0, child_2_layout.width());
+	assert_eq!(100.0, child_2_layout.height());
 
-	assert_eq!(100.0, child_3_layout.left);
-	assert_eq!(0.0, child_3_layout.top);
-	assert_eq!(0.0, child_3_layout.width);
-	assert_eq!(100.0, child_3_layout.height);
+	assert_eq!(100.0, child_3_layout.left());
+	assert_eq!(0.0, child_3_layout.top());
+	assert_eq!(0.0, child_3_layout.width());
+	assert_eq!(100.0, child_3_layout.height());
 
-	assert_eq!(100.0, child_4_layout.left);
-	assert_eq!(0.0, child_4_layout.top);
-	assert_eq!(50.0, child_4_layout.width);
-	assert_eq!(100.0, child_4_layout.height);
+	assert_eq!(100.0, child_4_layout.left());
+	assert_eq!(0.0, child_4_layout.top());
+	assert_eq!(50.0, child_4_layout.width());
+	assert_eq!(100.0, child_4_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
@@ -1285,35 +1285,35 @@ fn test_align_content_stretch_row_with_flex() {
 	let child_3_layout = root_child_3.get_layout();
 	let child_4_layout = root_child_4.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(150.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(150.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(100.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(100.0, child_0_layout.height);
+	assert_eq!(100.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(100.0, child_0_layout.height());
 
-	assert_eq!(100.0, child_1_layout.left);
-	assert_eq!(0.0, child_1_layout.top);
-	assert_eq!(0.0, child_1_layout.width);
-	assert_eq!(100.0, child_1_layout.height);
+	assert_eq!(100.0, child_1_layout.left());
+	assert_eq!(0.0, child_1_layout.top());
+	assert_eq!(0.0, child_1_layout.width());
+	assert_eq!(100.0, child_1_layout.height());
 
-	assert_eq!(50.0, child_2_layout.left);
-	assert_eq!(0.0, child_2_layout.top);
-	assert_eq!(50.0, child_2_layout.width);
-	assert_eq!(100.0, child_2_layout.height);
+	assert_eq!(50.0, child_2_layout.left());
+	assert_eq!(0.0, child_2_layout.top());
+	assert_eq!(50.0, child_2_layout.width());
+	assert_eq!(100.0, child_2_layout.height());
 
-	assert_eq!(50.0, child_3_layout.left);
-	assert_eq!(0.0, child_3_layout.top);
-	assert_eq!(0.0, child_3_layout.width);
-	assert_eq!(100.0, child_3_layout.height);
+	assert_eq!(50.0, child_3_layout.left());
+	assert_eq!(0.0, child_3_layout.top());
+	assert_eq!(0.0, child_3_layout.width());
+	assert_eq!(100.0, child_3_layout.height());
 
-	assert_eq!(0.0, child_4_layout.left);
-	assert_eq!(0.0, child_4_layout.top);
-	assert_eq!(50.0, child_4_layout.width);
-	assert_eq!(100.0, child_4_layout.height);
+	assert_eq!(0.0, child_4_layout.left());
+	assert_eq!(0.0, child_4_layout.top());
+	assert_eq!(50.0, child_4_layout.width());
+	assert_eq!(100.0, child_4_layout.height());
 }
 
 #[test]
@@ -1378,35 +1378,35 @@ fn test_align_content_stretch_row_with_flex_no_shrink() {
 	let child_3_layout = root_child_3.get_layout();
 	let child_4_layout = root_child_4.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(150.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(150.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(100.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(100.0, child_0_layout.height());
 
-	assert_eq!(50.0, child_1_layout.left);
-	assert_eq!(0.0, child_1_layout.top);
-	assert_eq!(0.0, child_1_layout.width);
-	assert_eq!(100.0, child_1_layout.height);
+	assert_eq!(50.0, child_1_layout.left());
+	assert_eq!(0.0, child_1_layout.top());
+	assert_eq!(0.0, child_1_layout.width());
+	assert_eq!(100.0, child_1_layout.height());
 
-	assert_eq!(50.0, child_2_layout.left);
-	assert_eq!(0.0, child_2_layout.top);
-	assert_eq!(50.0, child_2_layout.width);
-	assert_eq!(100.0, child_2_layout.height);
+	assert_eq!(50.0, child_2_layout.left());
+	assert_eq!(0.0, child_2_layout.top());
+	assert_eq!(50.0, child_2_layout.width());
+	assert_eq!(100.0, child_2_layout.height());
 
-	assert_eq!(100.0, child_3_layout.left);
-	assert_eq!(0.0, child_3_layout.top);
-	assert_eq!(0.0, child_3_layout.width);
-	assert_eq!(100.0, child_3_layout.height);
+	assert_eq!(100.0, child_3_layout.left());
+	assert_eq!(0.0, child_3_layout.top());
+	assert_eq!(0.0, child_3_layout.width());
+	assert_eq!(100.0, child_3_layout.height());
 
-	assert_eq!(100.0, child_4_layout.left);
-	assert_eq!(0.0, child_4_layout.top);
-	assert_eq!(50.0, child_4_layout.width);
-	assert_eq!(100.0, child_4_layout.height);
+	assert_eq!(100.0, child_4_layout.left());
+	assert_eq!(0.0, child_4_layout.top());
+	assert_eq!(50.0, child_4_layout.width());
+	assert_eq!(100.0, child_4_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
@@ -1417,35 +1417,35 @@ fn test_align_content_stretch_row_with_flex_no_shrink() {
 	let child_3_layout = root_child_3.get_layout();
 	let child_4_layout = root_child_4.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(150.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(150.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(100.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(100.0, child_0_layout.height);
+	assert_eq!(100.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(100.0, child_0_layout.height());
 
-	assert_eq!(100.0, child_1_layout.left);
-	assert_eq!(0.0, child_1_layout.top);
-	assert_eq!(0.0, child_1_layout.width);
-	assert_eq!(100.0, child_1_layout.height);
+	assert_eq!(100.0, child_1_layout.left());
+	assert_eq!(0.0, child_1_layout.top());
+	assert_eq!(0.0, child_1_layout.width());
+	assert_eq!(100.0, child_1_layout.height());
 
-	assert_eq!(50.0, child_2_layout.left);
-	assert_eq!(0.0, child_2_layout.top);
-	assert_eq!(50.0, child_2_layout.width);
-	assert_eq!(100.0, child_2_layout.height);
+	assert_eq!(50.0, child_2_layout.left());
+	assert_eq!(0.0, child_2_layout.top());
+	assert_eq!(50.0, child_2_layout.width());
+	assert_eq!(100.0, child_2_layout.height());
 
-	assert_eq!(50.0, child_3_layout.left);
-	assert_eq!(0.0, child_3_layout.top);
-	assert_eq!(0.0, child_3_layout.width);
-	assert_eq!(100.0, child_3_layout.height);
+	assert_eq!(50.0, child_3_layout.left());
+	assert_eq!(0.0, child_3_layout.top());
+	assert_eq!(0.0, child_3_layout.width());
+	assert_eq!(100.0, child_3_layout.height());
 
-	assert_eq!(0.0, child_4_layout.left);
-	assert_eq!(0.0, child_4_layout.top);
-	assert_eq!(50.0, child_4_layout.width);
-	assert_eq!(100.0, child_4_layout.height);
+	assert_eq!(0.0, child_4_layout.left());
+	assert_eq!(0.0, child_4_layout.top());
+	assert_eq!(50.0, child_4_layout.width());
+	assert_eq!(100.0, child_4_layout.height());
 }
 
 #[test]
@@ -1513,35 +1513,35 @@ fn test_align_content_stretch_row_with_margin() {
 	let child_3_layout = root_child_3.get_layout();
 	let child_4_layout = root_child_4.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(150.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(150.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(40.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(40.0, child_0_layout.height());
 
-	assert_eq!(60.0, child_1_layout.left);
-	assert_eq!(10.0, child_1_layout.top);
-	assert_eq!(50.0, child_1_layout.width);
-	assert_eq!(20.0, child_1_layout.height);
+	assert_eq!(60.0, child_1_layout.left());
+	assert_eq!(10.0, child_1_layout.top());
+	assert_eq!(50.0, child_1_layout.width());
+	assert_eq!(20.0, child_1_layout.height());
 
-	assert_eq!(0.0, child_2_layout.left);
-	assert_eq!(40.0, child_2_layout.top);
-	assert_eq!(50.0, child_2_layout.width);
-	assert_eq!(40.0, child_2_layout.height);
+	assert_eq!(0.0, child_2_layout.left());
+	assert_eq!(40.0, child_2_layout.top());
+	assert_eq!(50.0, child_2_layout.width());
+	assert_eq!(40.0, child_2_layout.height());
 
-	assert_eq!(60.0, child_3_layout.left);
-	assert_eq!(50.0, child_3_layout.top);
-	assert_eq!(50.0, child_3_layout.width);
-	assert_eq!(20.0, child_3_layout.height);
+	assert_eq!(60.0, child_3_layout.left());
+	assert_eq!(50.0, child_3_layout.top());
+	assert_eq!(50.0, child_3_layout.width());
+	assert_eq!(20.0, child_3_layout.height());
 
-	assert_eq!(0.0, child_4_layout.left);
-	assert_eq!(80.0, child_4_layout.top);
-	assert_eq!(50.0, child_4_layout.width);
-	assert_eq!(20.0, child_4_layout.height);
+	assert_eq!(0.0, child_4_layout.left());
+	assert_eq!(80.0, child_4_layout.top());
+	assert_eq!(50.0, child_4_layout.width());
+	assert_eq!(20.0, child_4_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
@@ -1552,35 +1552,35 @@ fn test_align_content_stretch_row_with_margin() {
 	let child_3_layout = root_child_3.get_layout();
 	let child_4_layout = root_child_4.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(150.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(150.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(100.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(40.0, child_0_layout.height);
+	assert_eq!(100.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(40.0, child_0_layout.height());
 
-	assert_eq!(40.0, child_1_layout.left);
-	assert_eq!(10.0, child_1_layout.top);
-	assert_eq!(50.0, child_1_layout.width);
-	assert_eq!(20.0, child_1_layout.height);
+	assert_eq!(40.0, child_1_layout.left());
+	assert_eq!(10.0, child_1_layout.top());
+	assert_eq!(50.0, child_1_layout.width());
+	assert_eq!(20.0, child_1_layout.height());
 
-	assert_eq!(100.0, child_2_layout.left);
-	assert_eq!(40.0, child_2_layout.top);
-	assert_eq!(50.0, child_2_layout.width);
-	assert_eq!(40.0, child_2_layout.height);
+	assert_eq!(100.0, child_2_layout.left());
+	assert_eq!(40.0, child_2_layout.top());
+	assert_eq!(50.0, child_2_layout.width());
+	assert_eq!(40.0, child_2_layout.height());
 
-	assert_eq!(40.0, child_3_layout.left);
-	assert_eq!(50.0, child_3_layout.top);
-	assert_eq!(50.0, child_3_layout.width);
-	assert_eq!(20.0, child_3_layout.height);
+	assert_eq!(40.0, child_3_layout.left());
+	assert_eq!(50.0, child_3_layout.top());
+	assert_eq!(50.0, child_3_layout.width());
+	assert_eq!(20.0, child_3_layout.height());
 
-	assert_eq!(100.0, child_4_layout.left);
-	assert_eq!(80.0, child_4_layout.top);
-	assert_eq!(50.0, child_4_layout.width);
-	assert_eq!(20.0, child_4_layout.height);
+	assert_eq!(100.0, child_4_layout.left());
+	assert_eq!(80.0, child_4_layout.top());
+	assert_eq!(50.0, child_4_layout.width());
+	assert_eq!(20.0, child_4_layout.height());
 }
 
 #[test]
@@ -1648,35 +1648,35 @@ fn test_align_content_stretch_row_with_padding() {
 	let child_3_layout = root_child_3.get_layout();
 	let child_4_layout = root_child_4.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(150.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(150.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(50.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(50.0, child_0_layout.height());
 
-	assert_eq!(50.0, child_1_layout.left);
-	assert_eq!(0.0, child_1_layout.top);
-	assert_eq!(50.0, child_1_layout.width);
-	assert_eq!(50.0, child_1_layout.height);
+	assert_eq!(50.0, child_1_layout.left());
+	assert_eq!(0.0, child_1_layout.top());
+	assert_eq!(50.0, child_1_layout.width());
+	assert_eq!(50.0, child_1_layout.height());
 
-	assert_eq!(100.0, child_2_layout.left);
-	assert_eq!(0.0, child_2_layout.top);
-	assert_eq!(50.0, child_2_layout.width);
-	assert_eq!(50.0, child_2_layout.height);
+	assert_eq!(100.0, child_2_layout.left());
+	assert_eq!(0.0, child_2_layout.top());
+	assert_eq!(50.0, child_2_layout.width());
+	assert_eq!(50.0, child_2_layout.height());
 
-	assert_eq!(0.0, child_3_layout.left);
-	assert_eq!(50.0, child_3_layout.top);
-	assert_eq!(50.0, child_3_layout.width);
-	assert_eq!(50.0, child_3_layout.height);
+	assert_eq!(0.0, child_3_layout.left());
+	assert_eq!(50.0, child_3_layout.top());
+	assert_eq!(50.0, child_3_layout.width());
+	assert_eq!(50.0, child_3_layout.height());
 
-	assert_eq!(50.0, child_4_layout.left);
-	assert_eq!(50.0, child_4_layout.top);
-	assert_eq!(50.0, child_4_layout.width);
-	assert_eq!(50.0, child_4_layout.height);
+	assert_eq!(50.0, child_4_layout.left());
+	assert_eq!(50.0, child_4_layout.top());
+	assert_eq!(50.0, child_4_layout.width());
+	assert_eq!(50.0, child_4_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
@@ -1687,35 +1687,35 @@ fn test_align_content_stretch_row_with_padding() {
 	let child_3_layout = root_child_3.get_layout();
 	let child_4_layout = root_child_4.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(150.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(150.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(100.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(50.0, child_0_layout.height);
+	assert_eq!(100.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(50.0, child_0_layout.height());
 
-	assert_eq!(50.0, child_1_layout.left);
-	assert_eq!(0.0, child_1_layout.top);
-	assert_eq!(50.0, child_1_layout.width);
-	assert_eq!(50.0, child_1_layout.height);
+	assert_eq!(50.0, child_1_layout.left());
+	assert_eq!(0.0, child_1_layout.top());
+	assert_eq!(50.0, child_1_layout.width());
+	assert_eq!(50.0, child_1_layout.height());
 
-	assert_eq!(0.0, child_2_layout.left);
-	assert_eq!(0.0, child_2_layout.top);
-	assert_eq!(50.0, child_2_layout.width);
-	assert_eq!(50.0, child_2_layout.height);
+	assert_eq!(0.0, child_2_layout.left());
+	assert_eq!(0.0, child_2_layout.top());
+	assert_eq!(50.0, child_2_layout.width());
+	assert_eq!(50.0, child_2_layout.height());
 
-	assert_eq!(100.0, child_3_layout.left);
-	assert_eq!(50.0, child_3_layout.top);
-	assert_eq!(50.0, child_3_layout.width);
-	assert_eq!(50.0, child_3_layout.height);
+	assert_eq!(100.0, child_3_layout.left());
+	assert_eq!(50.0, child_3_layout.top());
+	assert_eq!(50.0, child_3_layout.width());
+	assert_eq!(50.0, child_3_layout.height());
 
-	assert_eq!(50.0, child_4_layout.left);
-	assert_eq!(50.0, child_4_layout.top);
-	assert_eq!(50.0, child_4_layout.width);
-	assert_eq!(50.0, child_4_layout.height);
+	assert_eq!(50.0, child_4_layout.left());
+	assert_eq!(50.0, child_4_layout.top());
+	assert_eq!(50.0, child_4_layout.width());
+	assert_eq!(50.0, child_4_layout.height());
 }
 
 #[test]
@@ -1754,20 +1754,20 @@ fn test_align_content_stretch_row_with_single_row() {
 	let child_0_layout = root_child_0.get_layout();
 	let child_1_layout = root_child_1.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(150.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(150.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(100.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(100.0, child_0_layout.height());
 
-	assert_eq!(50.0, child_1_layout.left);
-	assert_eq!(0.0, child_1_layout.top);
-	assert_eq!(50.0, child_1_layout.width);
-	assert_eq!(100.0, child_1_layout.height);
+	assert_eq!(50.0, child_1_layout.left());
+	assert_eq!(0.0, child_1_layout.top());
+	assert_eq!(50.0, child_1_layout.width());
+	assert_eq!(100.0, child_1_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
@@ -1775,20 +1775,20 @@ fn test_align_content_stretch_row_with_single_row() {
 	let child_0_layout = root_child_0.get_layout();
 	let child_1_layout = root_child_1.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(150.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(150.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(100.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(100.0, child_0_layout.height);
+	assert_eq!(100.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(100.0, child_0_layout.height());
 
-	assert_eq!(50.0, child_1_layout.left);
-	assert_eq!(0.0, child_1_layout.top);
-	assert_eq!(50.0, child_1_layout.width);
-	assert_eq!(100.0, child_1_layout.height);
+	assert_eq!(50.0, child_1_layout.left());
+	assert_eq!(0.0, child_1_layout.top());
+	assert_eq!(50.0, child_1_layout.width());
+	assert_eq!(100.0, child_1_layout.height());
 }
 
 #[test]
@@ -1848,35 +1848,35 @@ fn test_align_content_stretch_row_with_fixed_height() {
 	let child_3_layout = root_child_3.get_layout();
 	let child_4_layout = root_child_4.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(150.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(150.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(80.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(80.0, child_0_layout.height());
 
-	assert_eq!(50.0, child_1_layout.left);
-	assert_eq!(0.0, child_1_layout.top);
-	assert_eq!(50.0, child_1_layout.width);
-	assert_eq!(60.0, child_1_layout.height);
+	assert_eq!(50.0, child_1_layout.left());
+	assert_eq!(0.0, child_1_layout.top());
+	assert_eq!(50.0, child_1_layout.width());
+	assert_eq!(60.0, child_1_layout.height());
 
-	assert_eq!(100.0, child_2_layout.left);
-	assert_eq!(0.0, child_2_layout.top);
-	assert_eq!(50.0, child_2_layout.width);
-	assert_eq!(80.0, child_2_layout.height);
+	assert_eq!(100.0, child_2_layout.left());
+	assert_eq!(0.0, child_2_layout.top());
+	assert_eq!(50.0, child_2_layout.width());
+	assert_eq!(80.0, child_2_layout.height());
 
-	assert_eq!(0.0, child_3_layout.left);
-	assert_eq!(80.0, child_3_layout.top);
-	assert_eq!(50.0, child_3_layout.width);
-	assert_eq!(20.0, child_3_layout.height);
+	assert_eq!(0.0, child_3_layout.left());
+	assert_eq!(80.0, child_3_layout.top());
+	assert_eq!(50.0, child_3_layout.width());
+	assert_eq!(20.0, child_3_layout.height());
 
-	assert_eq!(50.0, child_4_layout.left);
-	assert_eq!(80.0, child_4_layout.top);
-	assert_eq!(50.0, child_4_layout.width);
-	assert_eq!(20.0, child_4_layout.height);
+	assert_eq!(50.0, child_4_layout.left());
+	assert_eq!(80.0, child_4_layout.top());
+	assert_eq!(50.0, child_4_layout.width());
+	assert_eq!(20.0, child_4_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
@@ -1887,35 +1887,35 @@ fn test_align_content_stretch_row_with_fixed_height() {
 	let child_3_layout = root_child_3.get_layout();
 	let child_4_layout = root_child_4.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(150.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(150.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(100.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(80.0, child_0_layout.height);
+	assert_eq!(100.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(80.0, child_0_layout.height());
 
-	assert_eq!(50.0, child_1_layout.left);
-	assert_eq!(0.0, child_1_layout.top);
-	assert_eq!(50.0, child_1_layout.width);
-	assert_eq!(60.0, child_1_layout.height);
+	assert_eq!(50.0, child_1_layout.left());
+	assert_eq!(0.0, child_1_layout.top());
+	assert_eq!(50.0, child_1_layout.width());
+	assert_eq!(60.0, child_1_layout.height());
 
-	assert_eq!(0.0, child_2_layout.left);
-	assert_eq!(0.0, child_2_layout.top);
-	assert_eq!(50.0, child_2_layout.width);
-	assert_eq!(80.0, child_2_layout.height);
+	assert_eq!(0.0, child_2_layout.left());
+	assert_eq!(0.0, child_2_layout.top());
+	assert_eq!(50.0, child_2_layout.width());
+	assert_eq!(80.0, child_2_layout.height());
 
-	assert_eq!(100.0, child_3_layout.left);
-	assert_eq!(80.0, child_3_layout.top);
-	assert_eq!(50.0, child_3_layout.width);
-	assert_eq!(20.0, child_3_layout.height);
+	assert_eq!(100.0, child_3_layout.left());
+	assert_eq!(80.0, child_3_layout.top());
+	assert_eq!(50.0, child_3_layout.width());
+	assert_eq!(20.0, child_3_layout.height());
 
-	assert_eq!(50.0, child_4_layout.left);
-	assert_eq!(80.0, child_4_layout.top);
-	assert_eq!(50.0, child_4_layout.width);
-	assert_eq!(20.0, child_4_layout.height);
+	assert_eq!(50.0, child_4_layout.left());
+	assert_eq!(80.0, child_4_layout.top());
+	assert_eq!(50.0, child_4_layout.width());
+	assert_eq!(20.0, child_4_layout.height());
 }
 
 #[test]
@@ -1975,35 +1975,35 @@ fn test_align_content_stretch_row_with_max_height() {
 	let child_3_layout = root_child_3.get_layout();
 	let child_4_layout = root_child_4.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(150.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(150.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(50.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(50.0, child_0_layout.height());
 
-	assert_eq!(50.0, child_1_layout.left);
-	assert_eq!(0.0, child_1_layout.top);
-	assert_eq!(50.0, child_1_layout.width);
-	assert_eq!(20.0, child_1_layout.height);
+	assert_eq!(50.0, child_1_layout.left());
+	assert_eq!(0.0, child_1_layout.top());
+	assert_eq!(50.0, child_1_layout.width());
+	assert_eq!(20.0, child_1_layout.height());
 
-	assert_eq!(100.0, child_2_layout.left);
-	assert_eq!(0.0, child_2_layout.top);
-	assert_eq!(50.0, child_2_layout.width);
-	assert_eq!(50.0, child_2_layout.height);
+	assert_eq!(100.0, child_2_layout.left());
+	assert_eq!(0.0, child_2_layout.top());
+	assert_eq!(50.0, child_2_layout.width());
+	assert_eq!(50.0, child_2_layout.height());
 
-	assert_eq!(0.0, child_3_layout.left);
-	assert_eq!(50.0, child_3_layout.top);
-	assert_eq!(50.0, child_3_layout.width);
-	assert_eq!(50.0, child_3_layout.height);
+	assert_eq!(0.0, child_3_layout.left());
+	assert_eq!(50.0, child_3_layout.top());
+	assert_eq!(50.0, child_3_layout.width());
+	assert_eq!(50.0, child_3_layout.height());
 
-	assert_eq!(50.0, child_4_layout.left);
-	assert_eq!(50.0, child_4_layout.top);
-	assert_eq!(50.0, child_4_layout.width);
-	assert_eq!(50.0, child_4_layout.height);
+	assert_eq!(50.0, child_4_layout.left());
+	assert_eq!(50.0, child_4_layout.top());
+	assert_eq!(50.0, child_4_layout.width());
+	assert_eq!(50.0, child_4_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
@@ -2014,35 +2014,35 @@ fn test_align_content_stretch_row_with_max_height() {
 	let child_3_layout = root_child_3.get_layout();
 	let child_4_layout = root_child_4.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(150.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(150.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(100.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(50.0, child_0_layout.height);
+	assert_eq!(100.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(50.0, child_0_layout.height());
 
-	assert_eq!(50.0, child_1_layout.left);
-	assert_eq!(0.0, child_1_layout.top);
-	assert_eq!(50.0, child_1_layout.width);
-	assert_eq!(20.0, child_1_layout.height);
+	assert_eq!(50.0, child_1_layout.left());
+	assert_eq!(0.0, child_1_layout.top());
+	assert_eq!(50.0, child_1_layout.width());
+	assert_eq!(20.0, child_1_layout.height());
 
-	assert_eq!(0.0, child_2_layout.left);
-	assert_eq!(0.0, child_2_layout.top);
-	assert_eq!(50.0, child_2_layout.width);
-	assert_eq!(50.0, child_2_layout.height);
+	assert_eq!(0.0, child_2_layout.left());
+	assert_eq!(0.0, child_2_layout.top());
+	assert_eq!(50.0, child_2_layout.width());
+	assert_eq!(50.0, child_2_layout.height());
 
-	assert_eq!(100.0, child_3_layout.left);
-	assert_eq!(50.0, child_3_layout.top);
-	assert_eq!(50.0, child_3_layout.width);
-	assert_eq!(50.0, child_3_layout.height);
+	assert_eq!(100.0, child_3_layout.left());
+	assert_eq!(50.0, child_3_layout.top());
+	assert_eq!(50.0, child_3_layout.width());
+	assert_eq!(50.0, child_3_layout.height());
 
-	assert_eq!(50.0, child_4_layout.left);
-	assert_eq!(50.0, child_4_layout.top);
-	assert_eq!(50.0, child_4_layout.width);
-	assert_eq!(50.0, child_4_layout.height);
+	assert_eq!(50.0, child_4_layout.left());
+	assert_eq!(50.0, child_4_layout.top());
+	assert_eq!(50.0, child_4_layout.width());
+	assert_eq!(50.0, child_4_layout.height());
 }
 
 #[test]
@@ -2102,35 +2102,35 @@ fn test_align_content_stretch_row_with_min_height() {
 	let child_3_layout = root_child_3.get_layout();
 	let child_4_layout = root_child_4.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(150.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(150.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(90.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(90.0, child_0_layout.height());
 
-	assert_eq!(50.0, child_1_layout.left);
-	assert_eq!(0.0, child_1_layout.top);
-	assert_eq!(50.0, child_1_layout.width);
-	assert_eq!(90.0, child_1_layout.height);
+	assert_eq!(50.0, child_1_layout.left());
+	assert_eq!(0.0, child_1_layout.top());
+	assert_eq!(50.0, child_1_layout.width());
+	assert_eq!(90.0, child_1_layout.height());
 
-	assert_eq!(100.0, child_2_layout.left);
-	assert_eq!(0.0, child_2_layout.top);
-	assert_eq!(50.0, child_2_layout.width);
-	assert_eq!(90.0, child_2_layout.height);
+	assert_eq!(100.0, child_2_layout.left());
+	assert_eq!(0.0, child_2_layout.top());
+	assert_eq!(50.0, child_2_layout.width());
+	assert_eq!(90.0, child_2_layout.height());
 
-	assert_eq!(0.0, child_3_layout.left);
-	assert_eq!(90.0, child_3_layout.top);
-	assert_eq!(50.0, child_3_layout.width);
-	assert_eq!(10.0, child_3_layout.height);
+	assert_eq!(0.0, child_3_layout.left());
+	assert_eq!(90.0, child_3_layout.top());
+	assert_eq!(50.0, child_3_layout.width());
+	assert_eq!(10.0, child_3_layout.height());
 
-	assert_eq!(50.0, child_4_layout.left);
-	assert_eq!(90.0, child_4_layout.top);
-	assert_eq!(50.0, child_4_layout.width);
-	assert_eq!(10.0, child_4_layout.height);
+	assert_eq!(50.0, child_4_layout.left());
+	assert_eq!(90.0, child_4_layout.top());
+	assert_eq!(50.0, child_4_layout.width());
+	assert_eq!(10.0, child_4_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
@@ -2141,35 +2141,35 @@ fn test_align_content_stretch_row_with_min_height() {
 	let child_3_layout = root_child_3.get_layout();
 	let child_4_layout = root_child_4.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(150.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(150.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(100.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(90.0, child_0_layout.height);
+	assert_eq!(100.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(90.0, child_0_layout.height());
 
-	assert_eq!(50.0, child_1_layout.left);
-	assert_eq!(0.0, child_1_layout.top);
-	assert_eq!(50.0, child_1_layout.width);
-	assert_eq!(90.0, child_1_layout.height);
+	assert_eq!(50.0, child_1_layout.left());
+	assert_eq!(0.0, child_1_layout.top());
+	assert_eq!(50.0, child_1_layout.width());
+	assert_eq!(90.0, child_1_layout.height());
 
-	assert_eq!(0.0, child_2_layout.left);
-	assert_eq!(0.0, child_2_layout.top);
-	assert_eq!(50.0, child_2_layout.width);
-	assert_eq!(90.0, child_2_layout.height);
+	assert_eq!(0.0, child_2_layout.left());
+	assert_eq!(0.0, child_2_layout.top());
+	assert_eq!(50.0, child_2_layout.width());
+	assert_eq!(90.0, child_2_layout.height());
 
-	assert_eq!(100.0, child_3_layout.left);
-	assert_eq!(90.0, child_3_layout.top);
-	assert_eq!(50.0, child_3_layout.width);
-	assert_eq!(10.0, child_3_layout.height);
+	assert_eq!(100.0, child_3_layout.left());
+	assert_eq!(90.0, child_3_layout.top());
+	assert_eq!(50.0, child_3_layout.width());
+	assert_eq!(10.0, child_3_layout.height());
 
-	assert_eq!(50.0, child_4_layout.left);
-	assert_eq!(90.0, child_4_layout.top);
-	assert_eq!(50.0, child_4_layout.width);
-	assert_eq!(10.0, child_4_layout.height);
+	assert_eq!(50.0, child_4_layout.left());
+	assert_eq!(90.0, child_4_layout.top());
+	assert_eq!(50.0, child_4_layout.width());
+	assert_eq!(10.0, child_4_layout.height());
 }
 
 #[test]
@@ -2241,40 +2241,40 @@ fn test_align_content_stretch_column() {
 	let child_3_layout = root_child_3.get_layout();
 	let child_4_layout = root_child_4.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(150.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(150.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(50.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(50.0, child_0_layout.height());
 
-	assert_eq!(0.0, child_0_child_0_layout.left);
-	assert_eq!(0.0, child_0_child_0_layout.top);
-	assert_eq!(50.0, child_0_child_0_layout.width);
-	assert_eq!(50.0, child_0_child_0_layout.height);
+	assert_eq!(0.0, child_0_child_0_layout.left());
+	assert_eq!(0.0, child_0_child_0_layout.top());
+	assert_eq!(50.0, child_0_child_0_layout.width());
+	assert_eq!(50.0, child_0_child_0_layout.height());
 
-	assert_eq!(0.0, child_1_layout.left);
-	assert_eq!(50.0, child_1_layout.top);
-	assert_eq!(50.0, child_1_layout.width);
-	assert_eq!(0.0, child_1_layout.height);
+	assert_eq!(0.0, child_1_layout.left());
+	assert_eq!(50.0, child_1_layout.top());
+	assert_eq!(50.0, child_1_layout.width());
+	assert_eq!(0.0, child_1_layout.height());
 
-	assert_eq!(0.0, child_2_layout.left);
-	assert_eq!(50.0, child_2_layout.top);
-	assert_eq!(50.0, child_2_layout.width);
-	assert_eq!(50.0, child_2_layout.height);
+	assert_eq!(0.0, child_2_layout.left());
+	assert_eq!(50.0, child_2_layout.top());
+	assert_eq!(50.0, child_2_layout.width());
+	assert_eq!(50.0, child_2_layout.height());
 
-	assert_eq!(0.0, child_3_layout.left);
-	assert_eq!(100.0, child_3_layout.top);
-	assert_eq!(50.0, child_3_layout.width);
-	assert_eq!(50.0, child_3_layout.height);
+	assert_eq!(0.0, child_3_layout.left());
+	assert_eq!(100.0, child_3_layout.top());
+	assert_eq!(50.0, child_3_layout.width());
+	assert_eq!(50.0, child_3_layout.height());
 
-	assert_eq!(50.0, child_4_layout.left);
-	assert_eq!(0.0, child_4_layout.top);
-	assert_eq!(50.0, child_4_layout.width);
-	assert_eq!(50.0, child_4_layout.height);
+	assert_eq!(50.0, child_4_layout.left());
+	assert_eq!(0.0, child_4_layout.top());
+	assert_eq!(50.0, child_4_layout.width());
+	assert_eq!(50.0, child_4_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
@@ -2286,40 +2286,40 @@ fn test_align_content_stretch_column() {
 	let child_3_layout = root_child_3.get_layout();
 	let child_4_layout = root_child_4.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(150.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(150.0, root_layout.height());
 
-	assert_eq!(50.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(50.0, child_0_layout.height);
+	assert_eq!(50.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(50.0, child_0_layout.height());
 
-	assert_eq!(0.0, child_0_child_0_layout.left);
-	assert_eq!(0.0, child_0_child_0_layout.top);
-	assert_eq!(50.0, child_0_child_0_layout.width);
-	assert_eq!(50.0, child_0_child_0_layout.height);
+	assert_eq!(0.0, child_0_child_0_layout.left());
+	assert_eq!(0.0, child_0_child_0_layout.top());
+	assert_eq!(50.0, child_0_child_0_layout.width());
+	assert_eq!(50.0, child_0_child_0_layout.height());
 
-	assert_eq!(50.0, child_1_layout.left);
-	assert_eq!(50.0, child_1_layout.top);
-	assert_eq!(50.0, child_1_layout.width);
-	assert_eq!(0.0, child_1_layout.height);
+	assert_eq!(50.0, child_1_layout.left());
+	assert_eq!(50.0, child_1_layout.top());
+	assert_eq!(50.0, child_1_layout.width());
+	assert_eq!(0.0, child_1_layout.height());
 
-	assert_eq!(50.0, child_2_layout.left);
-	assert_eq!(50.0, child_2_layout.top);
-	assert_eq!(50.0, child_2_layout.width);
-	assert_eq!(50.0, child_2_layout.height);
+	assert_eq!(50.0, child_2_layout.left());
+	assert_eq!(50.0, child_2_layout.top());
+	assert_eq!(50.0, child_2_layout.width());
+	assert_eq!(50.0, child_2_layout.height());
 
-	assert_eq!(50.0, child_3_layout.left);
-	assert_eq!(100.0, child_3_layout.top);
-	assert_eq!(50.0, child_3_layout.width);
-	assert_eq!(50.0, child_3_layout.height);
+	assert_eq!(50.0, child_3_layout.left());
+	assert_eq!(100.0, child_3_layout.top());
+	assert_eq!(50.0, child_3_layout.width());
+	assert_eq!(50.0, child_3_layout.height());
 
-	assert_eq!(0.0, child_4_layout.left);
-	assert_eq!(0.0, child_4_layout.top);
-	assert_eq!(50.0, child_4_layout.width);
-	assert_eq!(50.0, child_4_layout.height);
+	assert_eq!(0.0, child_4_layout.left());
+	assert_eq!(0.0, child_4_layout.top());
+	assert_eq!(50.0, child_4_layout.width());
+	assert_eq!(50.0, child_4_layout.height());
 }
 
 #[test]
@@ -2355,20 +2355,20 @@ fn test_align_content_stretch_is_not_overriding_align_items() {
 	let child_0_layout = root_child_0.get_layout();
 	let child_0_child_0_layout = root_child_0_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(100.0, child_0_layout.width);
-	assert_eq!(100.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(100.0, child_0_layout.width());
+	assert_eq!(100.0, child_0_layout.height());
 
-	assert_eq!(0.0, child_0_child_0_layout.left);
-	assert_eq!(45.0, child_0_child_0_layout.top);
-	assert_eq!(10.0, child_0_child_0_layout.width);
-	assert_eq!(10.0, child_0_child_0_layout.height);
+	assert_eq!(0.0, child_0_child_0_layout.left());
+	assert_eq!(45.0, child_0_child_0_layout.top());
+	assert_eq!(10.0, child_0_child_0_layout.width());
+	assert_eq!(10.0, child_0_child_0_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
@@ -2376,18 +2376,18 @@ fn test_align_content_stretch_is_not_overriding_align_items() {
 	let child_0_layout = root_child_0.get_layout();
 	let child_0_child_0_layout = root_child_0_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(100.0, child_0_layout.width);
-	assert_eq!(100.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(100.0, child_0_layout.width());
+	assert_eq!(100.0, child_0_layout.height());
 
-	assert_eq!(90.0, child_0_child_0_layout.left);
-	assert_eq!(45.0, child_0_child_0_layout.top);
-	assert_eq!(10.0, child_0_child_0_layout.width);
-	assert_eq!(10.0, child_0_child_0_layout.height);
+	assert_eq!(90.0, child_0_child_0_layout.left());
+	assert_eq!(45.0, child_0_child_0_layout.top());
+	assert_eq!(10.0, child_0_child_0_layout.width());
+	assert_eq!(10.0, child_0_child_0_layout.height());
 }

--- a/tests/align_items_test.rs
+++ b/tests/align_items_test.rs
@@ -26,30 +26,30 @@ fn test_align_items_stretch() {
 	let root_layout = root.get_layout();
 	let child_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_layout.left);
-	assert_eq!(0.0, child_layout.top);
-	assert_eq!(100.0, child_layout.width);
-	assert_eq!(10.0, child_layout.height);
+	assert_eq!(0.0, child_layout.left());
+	assert_eq!(0.0, child_layout.top());
+	assert_eq!(100.0, child_layout.width());
+	assert_eq!(10.0, child_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
 	let root_layout = root.get_layout();
 	let child_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_layout.left);
-	assert_eq!(0.0, child_layout.top);
-	assert_eq!(100.0, child_layout.width);
-	assert_eq!(10.0, child_layout.height);
+	assert_eq!(0.0, child_layout.left());
+	assert_eq!(0.0, child_layout.top());
+	assert_eq!(100.0, child_layout.width());
+	assert_eq!(10.0, child_layout.height());
 }
 
 #[test]
@@ -75,30 +75,30 @@ fn test_align_items_center() {
 	let root_layout = root.get_layout();
 	let child_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(45.0, child_layout.left);
-	assert_eq!(0.0, child_layout.top);
-	assert_eq!(10.0, child_layout.width);
-	assert_eq!(10.0, child_layout.height);
+	assert_eq!(45.0, child_layout.left());
+	assert_eq!(0.0, child_layout.top());
+	assert_eq!(10.0, child_layout.width());
+	assert_eq!(10.0, child_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
 	let root_layout = root.get_layout();
 	let child_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(45.0, child_layout.left);
-	assert_eq!(0.0, child_layout.top);
-	assert_eq!(10.0, child_layout.width);
-	assert_eq!(10.0, child_layout.height);
+	assert_eq!(45.0, child_layout.left());
+	assert_eq!(0.0, child_layout.top());
+	assert_eq!(10.0, child_layout.width());
+	assert_eq!(10.0, child_layout.height());
 }
 
 #[test]
@@ -124,30 +124,30 @@ fn test_align_items_flex_start() {
 	let root_layout = root.get_layout();
 	let child_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_layout.left);
-	assert_eq!(0.0, child_layout.top);
-	assert_eq!(10.0, child_layout.width);
-	assert_eq!(10.0, child_layout.height);
+	assert_eq!(0.0, child_layout.left());
+	assert_eq!(0.0, child_layout.top());
+	assert_eq!(10.0, child_layout.width());
+	assert_eq!(10.0, child_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
 	let root_layout = root.get_layout();
 	let child_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(90.0, child_layout.left);
-	assert_eq!(0.0, child_layout.top);
-	assert_eq!(10.0, child_layout.width);
-	assert_eq!(10.0, child_layout.height);
+	assert_eq!(90.0, child_layout.left());
+	assert_eq!(0.0, child_layout.top());
+	assert_eq!(10.0, child_layout.width());
+	assert_eq!(10.0, child_layout.height());
 }
 
 #[test]
@@ -173,30 +173,30 @@ fn test_align_items_flex_end() {
 	let root_layout = root.get_layout();
 	let child_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(90.0, child_layout.left);
-	assert_eq!(0.0, child_layout.top);
-	assert_eq!(10.0, child_layout.width);
-	assert_eq!(10.0, child_layout.height);
+	assert_eq!(90.0, child_layout.left());
+	assert_eq!(0.0, child_layout.top());
+	assert_eq!(10.0, child_layout.width());
+	assert_eq!(10.0, child_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
 	let root_layout = root.get_layout();
 	let child_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_layout.left);
-	assert_eq!(0.0, child_layout.top);
-	assert_eq!(10.0, child_layout.width);
-	assert_eq!(10.0, child_layout.height);
+	assert_eq!(0.0, child_layout.left());
+	assert_eq!(0.0, child_layout.top());
+	assert_eq!(10.0, child_layout.width());
+	assert_eq!(10.0, child_layout.height());
 }
 
 #[test]
@@ -232,20 +232,20 @@ fn test_align_baseline() {
 	let child_0_layout = root_child_0.get_layout();
 	let child_1_layout = root_child_1.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(50.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(50.0, child_0_layout.height());
 
-	assert_eq!(50.0, child_1_layout.left);
-	assert_eq!(30.0, child_1_layout.top);
-	assert_eq!(50.0, child_1_layout.width);
-	assert_eq!(20.0, child_1_layout.height);
+	assert_eq!(50.0, child_1_layout.left());
+	assert_eq!(30.0, child_1_layout.top());
+	assert_eq!(50.0, child_1_layout.width());
+	assert_eq!(20.0, child_1_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
@@ -253,20 +253,20 @@ fn test_align_baseline() {
 	let child_0_layout = root_child_0.get_layout();
 	let child_1_layout = root_child_1.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(50.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(50.0, child_0_layout.height);
+	assert_eq!(50.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(50.0, child_0_layout.height());
 
-	assert_eq!(0.0, child_1_layout.left);
-	assert_eq!(30.0, child_1_layout.top);
-	assert_eq!(50.0, child_1_layout.width);
-	assert_eq!(20.0, child_1_layout.height);
+	assert_eq!(0.0, child_1_layout.left());
+	assert_eq!(30.0, child_1_layout.top());
+	assert_eq!(50.0, child_1_layout.width());
+	assert_eq!(20.0, child_1_layout.height());
 }
 
 #[test]
@@ -313,25 +313,25 @@ fn test_align_baseline_child() {
 	let child_1_layout = root_child_1.get_layout();
 	let child_1_child_0_layout = root_child_1_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(50.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(50.0, child_0_layout.height());
 
-	assert_eq!(50.0, child_1_layout.left);
-	assert_eq!(40.0, child_1_layout.top);
-	assert_eq!(50.0, child_1_layout.width);
-	assert_eq!(20.0, child_1_layout.height);
+	assert_eq!(50.0, child_1_layout.left());
+	assert_eq!(40.0, child_1_layout.top());
+	assert_eq!(50.0, child_1_layout.width());
+	assert_eq!(20.0, child_1_layout.height());
 
-	assert_eq!(0.0, child_1_child_0_layout.left);
-	assert_eq!(0.0, child_1_child_0_layout.top);
-	assert_eq!(50.0, child_1_child_0_layout.width);
-	assert_eq!(10.0, child_1_child_0_layout.height);
+	assert_eq!(0.0, child_1_child_0_layout.left());
+	assert_eq!(0.0, child_1_child_0_layout.top());
+	assert_eq!(50.0, child_1_child_0_layout.width());
+	assert_eq!(10.0, child_1_child_0_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
@@ -340,25 +340,25 @@ fn test_align_baseline_child() {
 	let child_1_layout = root_child_1.get_layout();
 	let child_1_child_0_layout = root_child_1_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(50.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(50.0, child_0_layout.height);
+	assert_eq!(50.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(50.0, child_0_layout.height());
 
-	assert_eq!(0.0, child_1_layout.left);
-	assert_eq!(40.0, child_1_layout.top);
-	assert_eq!(50.0, child_1_layout.width);
-	assert_eq!(20.0, child_1_layout.height);
+	assert_eq!(0.0, child_1_layout.left());
+	assert_eq!(40.0, child_1_layout.top());
+	assert_eq!(50.0, child_1_layout.width());
+	assert_eq!(20.0, child_1_layout.height());
 
-	assert_eq!(0.0, child_1_child_0_layout.left);
-	assert_eq!(0.0, child_1_child_0_layout.top);
-	assert_eq!(50.0, child_1_child_0_layout.width);
-	assert_eq!(10.0, child_1_child_0_layout.height);
+	assert_eq!(0.0, child_1_child_0_layout.left());
+	assert_eq!(0.0, child_1_child_0_layout.top());
+	assert_eq!(50.0, child_1_child_0_layout.width());
+	assert_eq!(10.0, child_1_child_0_layout.height());
 }
 
 #[test]
@@ -434,40 +434,40 @@ fn test_align_baseline_child_multiline() {
 	let child_1_child_2_layout = root_child_1_child_2.get_layout();
 	let child_1_child_3_layout = root_child_1_child_3.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(60.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(60.0, child_0_layout.height());
 
-	assert_eq!(50.0, child_1_layout.left);
-	assert_eq!(40.0, child_1_layout.top);
-	assert_eq!(50.0, child_1_layout.width);
-	assert_eq!(25.0, child_1_layout.height);
+	assert_eq!(50.0, child_1_layout.left());
+	assert_eq!(40.0, child_1_layout.top());
+	assert_eq!(50.0, child_1_layout.width());
+	assert_eq!(25.0, child_1_layout.height());
 
-	assert_eq!(0.0, child_1_child_0_layout.left);
-	assert_eq!(0.0, child_1_child_0_layout.top);
-	assert_eq!(25.0, child_1_child_0_layout.width);
-	assert_eq!(20.0, child_1_child_0_layout.height);
+	assert_eq!(0.0, child_1_child_0_layout.left());
+	assert_eq!(0.0, child_1_child_0_layout.top());
+	assert_eq!(25.0, child_1_child_0_layout.width());
+	assert_eq!(20.0, child_1_child_0_layout.height());
 
-	assert_eq!(25.0, child_1_child_1_layout.left);
-	assert_eq!(0.0, child_1_child_1_layout.top);
-	assert_eq!(25.0, child_1_child_1_layout.width);
-	assert_eq!(10.0, child_1_child_1_layout.height);
+	assert_eq!(25.0, child_1_child_1_layout.left());
+	assert_eq!(0.0, child_1_child_1_layout.top());
+	assert_eq!(25.0, child_1_child_1_layout.width());
+	assert_eq!(10.0, child_1_child_1_layout.height());
 
-	assert_eq!(0.0, child_1_child_2_layout.left);
-	assert_eq!(20.0, child_1_child_2_layout.top);
-	assert_eq!(25.0, child_1_child_2_layout.width);
-	assert_eq!(20.0, child_1_child_2_layout.height);
+	assert_eq!(0.0, child_1_child_2_layout.left());
+	assert_eq!(20.0, child_1_child_2_layout.top());
+	assert_eq!(25.0, child_1_child_2_layout.width());
+	assert_eq!(20.0, child_1_child_2_layout.height());
 
-	assert_eq!(25.0, child_1_child_3_layout.left);
-	assert_eq!(20.0, child_1_child_3_layout.top);
-	assert_eq!(25.0, child_1_child_3_layout.width);
-	assert_eq!(10.0, child_1_child_3_layout.height);
+	assert_eq!(25.0, child_1_child_3_layout.left());
+	assert_eq!(20.0, child_1_child_3_layout.top());
+	assert_eq!(25.0, child_1_child_3_layout.width());
+	assert_eq!(10.0, child_1_child_3_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
@@ -479,40 +479,40 @@ fn test_align_baseline_child_multiline() {
 	let child_1_child_2_layout = root_child_1_child_2.get_layout();
 	let child_1_child_3_layout = root_child_1_child_3.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(50.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(60.0, child_0_layout.height);
+	assert_eq!(50.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(60.0, child_0_layout.height());
 
-	assert_eq!(0.0, child_1_layout.left);
-	assert_eq!(40.0, child_1_layout.top);
-	assert_eq!(50.0, child_1_layout.width);
-	assert_eq!(25.0, child_1_layout.height);
+	assert_eq!(0.0, child_1_layout.left());
+	assert_eq!(40.0, child_1_layout.top());
+	assert_eq!(50.0, child_1_layout.width());
+	assert_eq!(25.0, child_1_layout.height());
 
-	assert_eq!(25.0, child_1_child_0_layout.left);
-	assert_eq!(0.0, child_1_child_0_layout.top);
-	assert_eq!(25.0, child_1_child_0_layout.width);
-	assert_eq!(20.0, child_1_child_0_layout.height);
+	assert_eq!(25.0, child_1_child_0_layout.left());
+	assert_eq!(0.0, child_1_child_0_layout.top());
+	assert_eq!(25.0, child_1_child_0_layout.width());
+	assert_eq!(20.0, child_1_child_0_layout.height());
 
-	assert_eq!(0.0, child_1_child_1_layout.left);
-	assert_eq!(0.0, child_1_child_1_layout.top);
-	assert_eq!(25.0, child_1_child_1_layout.width);
-	assert_eq!(10.0, child_1_child_1_layout.height);
+	assert_eq!(0.0, child_1_child_1_layout.left());
+	assert_eq!(0.0, child_1_child_1_layout.top());
+	assert_eq!(25.0, child_1_child_1_layout.width());
+	assert_eq!(10.0, child_1_child_1_layout.height());
 
-	assert_eq!(25.0, child_1_child_2_layout.left);
-	assert_eq!(20.0, child_1_child_2_layout.top);
-	assert_eq!(25.0, child_1_child_2_layout.width);
-	assert_eq!(20.0, child_1_child_2_layout.height);
+	assert_eq!(25.0, child_1_child_2_layout.left());
+	assert_eq!(20.0, child_1_child_2_layout.top());
+	assert_eq!(25.0, child_1_child_2_layout.width());
+	assert_eq!(20.0, child_1_child_2_layout.height());
 
-	assert_eq!(0.0, child_1_child_3_layout.left);
-	assert_eq!(20.0, child_1_child_3_layout.top);
-	assert_eq!(25.0, child_1_child_3_layout.width);
-	assert_eq!(10.0, child_1_child_3_layout.height);
+	assert_eq!(0.0, child_1_child_3_layout.left());
+	assert_eq!(20.0, child_1_child_3_layout.top());
+	assert_eq!(25.0, child_1_child_3_layout.width());
+	assert_eq!(10.0, child_1_child_3_layout.height());
 }
 
 #[test]
@@ -590,40 +590,40 @@ fn test_align_baseline_child_multiline_override() {
 	let child_1_child_2_layout = root_child_1_child_2.get_layout();
 	let child_1_child_3_layout = root_child_1_child_3.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(60.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(60.0, child_0_layout.height());
 
-	assert_eq!(50.0, child_1_layout.left);
-	assert_eq!(50.0, child_1_layout.top);
-	assert_eq!(50.0, child_1_layout.width);
-	assert_eq!(25.0, child_1_layout.height);
+	assert_eq!(50.0, child_1_layout.left());
+	assert_eq!(50.0, child_1_layout.top());
+	assert_eq!(50.0, child_1_layout.width());
+	assert_eq!(25.0, child_1_layout.height());
 
-	assert_eq!(0.0, child_1_child_0_layout.left);
-	assert_eq!(0.0, child_1_child_0_layout.top);
-	assert_eq!(25.0, child_1_child_0_layout.width);
-	assert_eq!(20.0, child_1_child_0_layout.height);
+	assert_eq!(0.0, child_1_child_0_layout.left());
+	assert_eq!(0.0, child_1_child_0_layout.top());
+	assert_eq!(25.0, child_1_child_0_layout.width());
+	assert_eq!(20.0, child_1_child_0_layout.height());
 
-	assert_eq!(25.0, child_1_child_1_layout.left);
-	assert_eq!(0.0, child_1_child_1_layout.top);
-	assert_eq!(25.0, child_1_child_1_layout.width);
-	assert_eq!(10.0, child_1_child_1_layout.height);
+	assert_eq!(25.0, child_1_child_1_layout.left());
+	assert_eq!(0.0, child_1_child_1_layout.top());
+	assert_eq!(25.0, child_1_child_1_layout.width());
+	assert_eq!(10.0, child_1_child_1_layout.height());
 
-	assert_eq!(0.0, child_1_child_2_layout.left);
-	assert_eq!(20.0, child_1_child_2_layout.top);
-	assert_eq!(25.0, child_1_child_2_layout.width);
-	assert_eq!(20.0, child_1_child_2_layout.height);
+	assert_eq!(0.0, child_1_child_2_layout.left());
+	assert_eq!(20.0, child_1_child_2_layout.top());
+	assert_eq!(25.0, child_1_child_2_layout.width());
+	assert_eq!(20.0, child_1_child_2_layout.height());
 
-	assert_eq!(25.0, child_1_child_3_layout.left);
-	assert_eq!(20.0, child_1_child_3_layout.top);
-	assert_eq!(25.0, child_1_child_3_layout.width);
-	assert_eq!(10.0, child_1_child_3_layout.height);
+	assert_eq!(25.0, child_1_child_3_layout.left());
+	assert_eq!(20.0, child_1_child_3_layout.top());
+	assert_eq!(25.0, child_1_child_3_layout.width());
+	assert_eq!(10.0, child_1_child_3_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
@@ -635,40 +635,40 @@ fn test_align_baseline_child_multiline_override() {
 	let child_1_child_2_layout = root_child_1_child_2.get_layout();
 	let child_1_child_3_layout = root_child_1_child_3.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(50.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(60.0, child_0_layout.height);
+	assert_eq!(50.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(60.0, child_0_layout.height());
 
-	assert_eq!(0.0, child_1_layout.left);
-	assert_eq!(50.0, child_1_layout.top);
-	assert_eq!(50.0, child_1_layout.width);
-	assert_eq!(25.0, child_1_layout.height);
+	assert_eq!(0.0, child_1_layout.left());
+	assert_eq!(50.0, child_1_layout.top());
+	assert_eq!(50.0, child_1_layout.width());
+	assert_eq!(25.0, child_1_layout.height());
 
-	assert_eq!(25.0, child_1_child_0_layout.left);
-	assert_eq!(0.0, child_1_child_0_layout.top);
-	assert_eq!(25.0, child_1_child_0_layout.width);
-	assert_eq!(20.0, child_1_child_0_layout.height);
+	assert_eq!(25.0, child_1_child_0_layout.left());
+	assert_eq!(0.0, child_1_child_0_layout.top());
+	assert_eq!(25.0, child_1_child_0_layout.width());
+	assert_eq!(20.0, child_1_child_0_layout.height());
 
-	assert_eq!(0.0, child_1_child_1_layout.left);
-	assert_eq!(0.0, child_1_child_1_layout.top);
-	assert_eq!(25.0, child_1_child_1_layout.width);
-	assert_eq!(10.0, child_1_child_1_layout.height);
+	assert_eq!(0.0, child_1_child_1_layout.left());
+	assert_eq!(0.0, child_1_child_1_layout.top());
+	assert_eq!(25.0, child_1_child_1_layout.width());
+	assert_eq!(10.0, child_1_child_1_layout.height());
 
-	assert_eq!(25.0, child_1_child_2_layout.left);
-	assert_eq!(20.0, child_1_child_2_layout.top);
-	assert_eq!(25.0, child_1_child_2_layout.width);
-	assert_eq!(20.0, child_1_child_2_layout.height);
+	assert_eq!(25.0, child_1_child_2_layout.left());
+	assert_eq!(20.0, child_1_child_2_layout.top());
+	assert_eq!(25.0, child_1_child_2_layout.width());
+	assert_eq!(20.0, child_1_child_2_layout.height());
 
-	assert_eq!(0.0, child_1_child_3_layout.left);
-	assert_eq!(20.0, child_1_child_3_layout.top);
-	assert_eq!(25.0, child_1_child_3_layout.width);
-	assert_eq!(10.0, child_1_child_3_layout.height);
+	assert_eq!(0.0, child_1_child_3_layout.left());
+	assert_eq!(20.0, child_1_child_3_layout.top());
+	assert_eq!(25.0, child_1_child_3_layout.width());
+	assert_eq!(10.0, child_1_child_3_layout.height());
 }
 
 #[test]
@@ -744,40 +744,40 @@ fn test_align_baseline_child_multiline_no_override_on_secondline() {
 	let child_1_child_2_layout = root_child_1_child_2.get_layout();
 	let child_1_child_3_layout = root_child_1_child_3.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(60.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(60.0, child_0_layout.height());
 
-	assert_eq!(50.0, child_1_layout.left);
-	assert_eq!(40.0, child_1_layout.top);
-	assert_eq!(50.0, child_1_layout.width);
-	assert_eq!(25.0, child_1_layout.height);
+	assert_eq!(50.0, child_1_layout.left());
+	assert_eq!(40.0, child_1_layout.top());
+	assert_eq!(50.0, child_1_layout.width());
+	assert_eq!(25.0, child_1_layout.height());
 
-	assert_eq!(0.0, child_1_child_0_layout.left);
-	assert_eq!(0.0, child_1_child_0_layout.top);
-	assert_eq!(25.0, child_1_child_0_layout.width);
-	assert_eq!(20.0, child_1_child_0_layout.height);
+	assert_eq!(0.0, child_1_child_0_layout.left());
+	assert_eq!(0.0, child_1_child_0_layout.top());
+	assert_eq!(25.0, child_1_child_0_layout.width());
+	assert_eq!(20.0, child_1_child_0_layout.height());
 
-	assert_eq!(25.0, child_1_child_1_layout.left);
-	assert_eq!(0.0, child_1_child_1_layout.top);
-	assert_eq!(25.0, child_1_child_1_layout.width);
-	assert_eq!(10.0, child_1_child_1_layout.height);
+	assert_eq!(25.0, child_1_child_1_layout.left());
+	assert_eq!(0.0, child_1_child_1_layout.top());
+	assert_eq!(25.0, child_1_child_1_layout.width());
+	assert_eq!(10.0, child_1_child_1_layout.height());
 
-	assert_eq!(0.0, child_1_child_2_layout.left);
-	assert_eq!(20.0, child_1_child_2_layout.top);
-	assert_eq!(25.0, child_1_child_2_layout.width);
-	assert_eq!(20.0, child_1_child_2_layout.height);
+	assert_eq!(0.0, child_1_child_2_layout.left());
+	assert_eq!(20.0, child_1_child_2_layout.top());
+	assert_eq!(25.0, child_1_child_2_layout.width());
+	assert_eq!(20.0, child_1_child_2_layout.height());
 
-	assert_eq!(25.0, child_1_child_3_layout.left);
-	assert_eq!(20.0, child_1_child_3_layout.top);
-	assert_eq!(25.0, child_1_child_3_layout.width);
-	assert_eq!(10.0, child_1_child_3_layout.height);
+	assert_eq!(25.0, child_1_child_3_layout.left());
+	assert_eq!(20.0, child_1_child_3_layout.top());
+	assert_eq!(25.0, child_1_child_3_layout.width());
+	assert_eq!(10.0, child_1_child_3_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
@@ -789,40 +789,40 @@ fn test_align_baseline_child_multiline_no_override_on_secondline() {
 	let child_1_child_2_layout = root_child_1_child_2.get_layout();
 	let child_1_child_3_layout = root_child_1_child_3.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(50.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(60.0, child_0_layout.height);
+	assert_eq!(50.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(60.0, child_0_layout.height());
 
-	assert_eq!(0.0, child_1_layout.left);
-	assert_eq!(40.0, child_1_layout.top);
-	assert_eq!(50.0, child_1_layout.width);
-	assert_eq!(25.0, child_1_layout.height);
+	assert_eq!(0.0, child_1_layout.left());
+	assert_eq!(40.0, child_1_layout.top());
+	assert_eq!(50.0, child_1_layout.width());
+	assert_eq!(25.0, child_1_layout.height());
 
-	assert_eq!(25.0, child_1_child_0_layout.left);
-	assert_eq!(0.0, child_1_child_0_layout.top);
-	assert_eq!(25.0, child_1_child_0_layout.width);
-	assert_eq!(20.0, child_1_child_0_layout.height);
+	assert_eq!(25.0, child_1_child_0_layout.left());
+	assert_eq!(0.0, child_1_child_0_layout.top());
+	assert_eq!(25.0, child_1_child_0_layout.width());
+	assert_eq!(20.0, child_1_child_0_layout.height());
 
-	assert_eq!(0.0, child_1_child_1_layout.left);
-	assert_eq!(0.0, child_1_child_1_layout.top);
-	assert_eq!(25.0, child_1_child_1_layout.width);
-	assert_eq!(10.0, child_1_child_1_layout.height);
+	assert_eq!(0.0, child_1_child_1_layout.left());
+	assert_eq!(0.0, child_1_child_1_layout.top());
+	assert_eq!(25.0, child_1_child_1_layout.width());
+	assert_eq!(10.0, child_1_child_1_layout.height());
 
-	assert_eq!(25.0, child_1_child_2_layout.left);
-	assert_eq!(20.0, child_1_child_2_layout.top);
-	assert_eq!(25.0, child_1_child_2_layout.width);
-	assert_eq!(20.0, child_1_child_2_layout.height);
+	assert_eq!(25.0, child_1_child_2_layout.left());
+	assert_eq!(20.0, child_1_child_2_layout.top());
+	assert_eq!(25.0, child_1_child_2_layout.width());
+	assert_eq!(20.0, child_1_child_2_layout.height());
 
-	assert_eq!(0.0, child_1_child_3_layout.left);
-	assert_eq!(20.0, child_1_child_3_layout.top);
-	assert_eq!(25.0, child_1_child_3_layout.width);
-	assert_eq!(10.0, child_1_child_3_layout.height);
+	assert_eq!(0.0, child_1_child_3_layout.left());
+	assert_eq!(20.0, child_1_child_3_layout.top());
+	assert_eq!(25.0, child_1_child_3_layout.width());
+	assert_eq!(10.0, child_1_child_3_layout.height());
 }
 
 #[test]
@@ -869,25 +869,25 @@ fn test_align_baseline_child_top() {
 	let child_1_layout = root_child_1.get_layout();
 	let child_1_child_0_layout = root_child_1_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(10.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(50.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(10.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(50.0, child_0_layout.height());
 
-	assert_eq!(50.0, child_1_layout.left);
-	assert_eq!(40.0, child_1_layout.top);
-	assert_eq!(50.0, child_1_layout.width);
-	assert_eq!(20.0, child_1_layout.height);
+	assert_eq!(50.0, child_1_layout.left());
+	assert_eq!(40.0, child_1_layout.top());
+	assert_eq!(50.0, child_1_layout.width());
+	assert_eq!(20.0, child_1_layout.height());
 
-	assert_eq!(0.0, child_1_child_0_layout.left);
-	assert_eq!(0.0, child_1_child_0_layout.top);
-	assert_eq!(50.0, child_1_child_0_layout.width);
-	assert_eq!(10.0, child_1_child_0_layout.height);
+	assert_eq!(0.0, child_1_child_0_layout.left());
+	assert_eq!(0.0, child_1_child_0_layout.top());
+	assert_eq!(50.0, child_1_child_0_layout.width());
+	assert_eq!(10.0, child_1_child_0_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
@@ -896,25 +896,25 @@ fn test_align_baseline_child_top() {
 	let child_1_layout = root_child_1.get_layout();
 	let child_1_child_0_layout = root_child_1_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(50.0, child_0_layout.left);
-	assert_eq!(10.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(50.0, child_0_layout.height);
+	assert_eq!(50.0, child_0_layout.left());
+	assert_eq!(10.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(50.0, child_0_layout.height());
 
-	assert_eq!(0.0, child_1_layout.left);
-	assert_eq!(40.0, child_1_layout.top);
-	assert_eq!(50.0, child_1_layout.width);
-	assert_eq!(20.0, child_1_layout.height);
+	assert_eq!(0.0, child_1_layout.left());
+	assert_eq!(40.0, child_1_layout.top());
+	assert_eq!(50.0, child_1_layout.width());
+	assert_eq!(20.0, child_1_layout.height());
 
-	assert_eq!(0.0, child_1_child_0_layout.left);
-	assert_eq!(0.0, child_1_child_0_layout.top);
-	assert_eq!(50.0, child_1_child_0_layout.width);
-	assert_eq!(10.0, child_1_child_0_layout.height);
+	assert_eq!(0.0, child_1_child_0_layout.left());
+	assert_eq!(0.0, child_1_child_0_layout.top());
+	assert_eq!(50.0, child_1_child_0_layout.width());
+	assert_eq!(10.0, child_1_child_0_layout.height());
 }
 
 #[test]
@@ -961,25 +961,25 @@ fn test_align_baseline_child_top2() {
 	let child_1_layout = root_child_1.get_layout();
 	let child_1_child_0_layout = root_child_1_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(50.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(50.0, child_0_layout.height());
 
-	assert_eq!(50.0, child_1_layout.left);
-	assert_eq!(45.0, child_1_layout.top);
-	assert_eq!(50.0, child_1_layout.width);
-	assert_eq!(20.0, child_1_layout.height);
+	assert_eq!(50.0, child_1_layout.left());
+	assert_eq!(45.0, child_1_layout.top());
+	assert_eq!(50.0, child_1_layout.width());
+	assert_eq!(20.0, child_1_layout.height());
 
-	assert_eq!(0.0, child_1_child_0_layout.left);
-	assert_eq!(0.0, child_1_child_0_layout.top);
-	assert_eq!(50.0, child_1_child_0_layout.width);
-	assert_eq!(10.0, child_1_child_0_layout.height);
+	assert_eq!(0.0, child_1_child_0_layout.left());
+	assert_eq!(0.0, child_1_child_0_layout.top());
+	assert_eq!(50.0, child_1_child_0_layout.width());
+	assert_eq!(10.0, child_1_child_0_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
@@ -988,25 +988,25 @@ fn test_align_baseline_child_top2() {
 	let child_1_layout = root_child_1.get_layout();
 	let child_1_child_0_layout = root_child_1_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(50.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(50.0, child_0_layout.height);
+	assert_eq!(50.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(50.0, child_0_layout.height());
 
-	assert_eq!(0.0, child_1_layout.left);
-	assert_eq!(45.0, child_1_layout.top);
-	assert_eq!(50.0, child_1_layout.width);
-	assert_eq!(20.0, child_1_layout.height);
+	assert_eq!(0.0, child_1_layout.left());
+	assert_eq!(45.0, child_1_layout.top());
+	assert_eq!(50.0, child_1_layout.width());
+	assert_eq!(20.0, child_1_layout.height());
 
-	assert_eq!(0.0, child_1_child_0_layout.left);
-	assert_eq!(0.0, child_1_child_0_layout.top);
-	assert_eq!(50.0, child_1_child_0_layout.width);
-	assert_eq!(10.0, child_1_child_0_layout.height);
+	assert_eq!(0.0, child_1_child_0_layout.left());
+	assert_eq!(0.0, child_1_child_0_layout.top());
+	assert_eq!(50.0, child_1_child_0_layout.width());
+	assert_eq!(10.0, child_1_child_0_layout.height());
 }
 
 #[test]
@@ -1061,30 +1061,30 @@ fn test_align_baseline_double_nested_child() {
 	let child_1_layout = root_child_1.get_layout();
 	let child_1_child_0_layout = root_child_1_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(50.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(50.0, child_0_layout.height());
 
-	assert_eq!(0.0, child_0_child_0_layout.left);
-	assert_eq!(0.0, child_0_child_0_layout.top);
-	assert_eq!(50.0, child_0_child_0_layout.width);
-	assert_eq!(20.0, child_0_child_0_layout.height);
+	assert_eq!(0.0, child_0_child_0_layout.left());
+	assert_eq!(0.0, child_0_child_0_layout.top());
+	assert_eq!(50.0, child_0_child_0_layout.width());
+	assert_eq!(20.0, child_0_child_0_layout.height());
 
-	assert_eq!(50.0, child_1_layout.left);
-	assert_eq!(5.0, child_1_layout.top);
-	assert_eq!(50.0, child_1_layout.width);
-	assert_eq!(20.0, child_1_layout.height);
+	assert_eq!(50.0, child_1_layout.left());
+	assert_eq!(5.0, child_1_layout.top());
+	assert_eq!(50.0, child_1_layout.width());
+	assert_eq!(20.0, child_1_layout.height());
 
-	assert_eq!(0.0, child_1_child_0_layout.left);
-	assert_eq!(0.0, child_1_child_0_layout.top);
-	assert_eq!(50.0, child_1_child_0_layout.width);
-	assert_eq!(15.0, child_1_child_0_layout.height);
+	assert_eq!(0.0, child_1_child_0_layout.left());
+	assert_eq!(0.0, child_1_child_0_layout.top());
+	assert_eq!(50.0, child_1_child_0_layout.width());
+	assert_eq!(15.0, child_1_child_0_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
@@ -1094,30 +1094,30 @@ fn test_align_baseline_double_nested_child() {
 	let child_1_layout = root_child_1.get_layout();
 	let child_1_child_0_layout = root_child_1_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(50.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(50.0, child_0_layout.height);
+	assert_eq!(50.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(50.0, child_0_layout.height());
 
-	assert_eq!(0.0, child_0_child_0_layout.left);
-	assert_eq!(0.0, child_0_child_0_layout.top);
-	assert_eq!(50.0, child_0_child_0_layout.width);
-	assert_eq!(20.0, child_0_child_0_layout.height);
+	assert_eq!(0.0, child_0_child_0_layout.left());
+	assert_eq!(0.0, child_0_child_0_layout.top());
+	assert_eq!(50.0, child_0_child_0_layout.width());
+	assert_eq!(20.0, child_0_child_0_layout.height());
 
-	assert_eq!(0.0, child_1_layout.left);
-	assert_eq!(5.0, child_1_layout.top);
-	assert_eq!(50.0, child_1_layout.width);
-	assert_eq!(20.0, child_1_layout.height);
+	assert_eq!(0.0, child_1_layout.left());
+	assert_eq!(5.0, child_1_layout.top());
+	assert_eq!(50.0, child_1_layout.width());
+	assert_eq!(20.0, child_1_layout.height());
 
-	assert_eq!(0.0, child_1_child_0_layout.left);
-	assert_eq!(0.0, child_1_child_0_layout.top);
-	assert_eq!(50.0, child_1_child_0_layout.width);
-	assert_eq!(15.0, child_1_child_0_layout.height);
+	assert_eq!(0.0, child_1_child_0_layout.left());
+	assert_eq!(0.0, child_1_child_0_layout.top());
+	assert_eq!(50.0, child_1_child_0_layout.width());
+	assert_eq!(15.0, child_1_child_0_layout.height());
 }
 
 #[test]
@@ -1152,20 +1152,20 @@ fn test_align_baseline_column() {
 	let child_0_layout = root_child_0.get_layout();
 	let child_1_layout = root_child_1.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(50.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(50.0, child_0_layout.height());
 
-	assert_eq!(0.0, child_1_layout.left);
-	assert_eq!(50.0, child_1_layout.top);
-	assert_eq!(50.0, child_1_layout.width);
-	assert_eq!(20.0, child_1_layout.height);
+	assert_eq!(0.0, child_1_layout.left());
+	assert_eq!(50.0, child_1_layout.top());
+	assert_eq!(50.0, child_1_layout.width());
+	assert_eq!(20.0, child_1_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
@@ -1173,20 +1173,20 @@ fn test_align_baseline_column() {
 	let child_0_layout = root_child_0.get_layout();
 	let child_1_layout = root_child_1.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(50.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(50.0, child_0_layout.height);
+	assert_eq!(50.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(50.0, child_0_layout.height());
 
-	assert_eq!(50.0, child_1_layout.left);
-	assert_eq!(50.0, child_1_layout.top);
-	assert_eq!(50.0, child_1_layout.width);
-	assert_eq!(20.0, child_1_layout.height);
+	assert_eq!(50.0, child_1_layout.left());
+	assert_eq!(50.0, child_1_layout.top());
+	assert_eq!(50.0, child_1_layout.width());
+	assert_eq!(20.0, child_1_layout.height());
 }
 
 #[test]
@@ -1240,25 +1240,25 @@ fn test_align_baseline_child_margin() {
 	let child_1_layout = root_child_1.get_layout();
 	let child_1_child_0_layout = root_child_1_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(5.0, child_0_layout.left);
-	assert_eq!(5.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(50.0, child_0_layout.height);
+	assert_eq!(5.0, child_0_layout.left());
+	assert_eq!(5.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(50.0, child_0_layout.height());
 
-	assert_eq!(60.0, child_1_layout.left);
-	assert_eq!(44.0, child_1_layout.top);
-	assert_eq!(50.0, child_1_layout.width);
-	assert_eq!(20.0, child_1_layout.height);
+	assert_eq!(60.0, child_1_layout.left());
+	assert_eq!(44.0, child_1_layout.top());
+	assert_eq!(50.0, child_1_layout.width());
+	assert_eq!(20.0, child_1_layout.height());
 
-	assert_eq!(1.0, child_1_child_0_layout.left);
-	assert_eq!(1.0, child_1_child_0_layout.top);
-	assert_eq!(50.0, child_1_child_0_layout.width);
-	assert_eq!(10.0, child_1_child_0_layout.height);
+	assert_eq!(1.0, child_1_child_0_layout.left());
+	assert_eq!(1.0, child_1_child_0_layout.top());
+	assert_eq!(50.0, child_1_child_0_layout.width());
+	assert_eq!(10.0, child_1_child_0_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
@@ -1267,25 +1267,25 @@ fn test_align_baseline_child_margin() {
 	let child_1_layout = root_child_1.get_layout();
 	let child_1_child_0_layout = root_child_1_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(45.0, child_0_layout.left);
-	assert_eq!(5.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(50.0, child_0_layout.height);
+	assert_eq!(45.0, child_0_layout.left());
+	assert_eq!(5.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(50.0, child_0_layout.height());
 
-	assert_eq!(-10.0, child_1_layout.left);
-	assert_eq!(44.0, child_1_layout.top);
-	assert_eq!(50.0, child_1_layout.width);
-	assert_eq!(20.0, child_1_layout.height);
+	assert_eq!(-10.0, child_1_layout.left());
+	assert_eq!(44.0, child_1_layout.top());
+	assert_eq!(50.0, child_1_layout.width());
+	assert_eq!(20.0, child_1_layout.height());
 
-	assert_eq!(-1.0, child_1_child_0_layout.left);
-	assert_eq!(1.0, child_1_child_0_layout.top);
-	assert_eq!(50.0, child_1_child_0_layout.width);
-	assert_eq!(10.0, child_1_child_0_layout.height);
+	assert_eq!(-1.0, child_1_child_0_layout.left());
+	assert_eq!(1.0, child_1_child_0_layout.top());
+	assert_eq!(50.0, child_1_child_0_layout.width());
+	assert_eq!(10.0, child_1_child_0_layout.height());
 }
 
 #[test]
@@ -1339,25 +1339,25 @@ fn test_align_baseline_child_padding() {
 	let child_1_layout = root_child_1.get_layout();
 	let child_1_child_0_layout = root_child_1_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(5.0, child_0_layout.left);
-	assert_eq!(5.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(50.0, child_0_layout.height);
+	assert_eq!(5.0, child_0_layout.left());
+	assert_eq!(5.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(50.0, child_0_layout.height());
 
-	assert_eq!(55.0, child_1_layout.left);
-	assert_eq!(40.0, child_1_layout.top);
-	assert_eq!(50.0, child_1_layout.width);
-	assert_eq!(20.0, child_1_layout.height);
+	assert_eq!(55.0, child_1_layout.left());
+	assert_eq!(40.0, child_1_layout.top());
+	assert_eq!(50.0, child_1_layout.width());
+	assert_eq!(20.0, child_1_layout.height());
 
-	assert_eq!(5.0, child_1_child_0_layout.left);
-	assert_eq!(5.0, child_1_child_0_layout.top);
-	assert_eq!(50.0, child_1_child_0_layout.width);
-	assert_eq!(10.0, child_1_child_0_layout.height);
+	assert_eq!(5.0, child_1_child_0_layout.left());
+	assert_eq!(5.0, child_1_child_0_layout.top());
+	assert_eq!(50.0, child_1_child_0_layout.width());
+	assert_eq!(10.0, child_1_child_0_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
@@ -1366,25 +1366,25 @@ fn test_align_baseline_child_padding() {
 	let child_1_layout = root_child_1.get_layout();
 	let child_1_child_0_layout = root_child_1_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(45.0, child_0_layout.left);
-	assert_eq!(5.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(50.0, child_0_layout.height);
+	assert_eq!(45.0, child_0_layout.left());
+	assert_eq!(5.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(50.0, child_0_layout.height());
 
-	assert_eq!(-5.0, child_1_layout.left);
-	assert_eq!(40.0, child_1_layout.top);
-	assert_eq!(50.0, child_1_layout.width);
-	assert_eq!(20.0, child_1_layout.height);
+	assert_eq!(-5.0, child_1_layout.left());
+	assert_eq!(40.0, child_1_layout.top());
+	assert_eq!(50.0, child_1_layout.width());
+	assert_eq!(20.0, child_1_layout.height());
 
-	assert_eq!(-5.0, child_1_child_0_layout.left);
-	assert_eq!(5.0, child_1_child_0_layout.top);
-	assert_eq!(50.0, child_1_child_0_layout.width);
-	assert_eq!(10.0, child_1_child_0_layout.height);
+	assert_eq!(-5.0, child_1_child_0_layout.left());
+	assert_eq!(5.0, child_1_child_0_layout.top());
+	assert_eq!(50.0, child_1_child_0_layout.width());
+	assert_eq!(10.0, child_1_child_0_layout.height());
 }
 
 #[test]
@@ -1458,40 +1458,40 @@ fn test_align_baseline_multiline() {
 	let child_2_child_0_layout = root_child_2_child_0.get_layout();
 	let child_3_layout = root_child_3.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(50.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(50.0, child_0_layout.height());
 
-	assert_eq!(50.0, child_1_layout.left);
-	assert_eq!(40.0, child_1_layout.top);
-	assert_eq!(50.0, child_1_layout.width);
-	assert_eq!(20.0, child_1_layout.height);
+	assert_eq!(50.0, child_1_layout.left());
+	assert_eq!(40.0, child_1_layout.top());
+	assert_eq!(50.0, child_1_layout.width());
+	assert_eq!(20.0, child_1_layout.height());
 
-	assert_eq!(0.0, child_1_child_0_layout.left);
-	assert_eq!(0.0, child_1_child_0_layout.top);
-	assert_eq!(50.0, child_1_child_0_layout.width);
-	assert_eq!(10.0, child_1_child_0_layout.height);
+	assert_eq!(0.0, child_1_child_0_layout.left());
+	assert_eq!(0.0, child_1_child_0_layout.top());
+	assert_eq!(50.0, child_1_child_0_layout.width());
+	assert_eq!(10.0, child_1_child_0_layout.height());
 
-	assert_eq!(0.0, child_2_layout.left);
-	assert_eq!(100.0, child_2_layout.top);
-	assert_eq!(50.0, child_2_layout.width);
-	assert_eq!(20.0, child_2_layout.height);
+	assert_eq!(0.0, child_2_layout.left());
+	assert_eq!(100.0, child_2_layout.top());
+	assert_eq!(50.0, child_2_layout.width());
+	assert_eq!(20.0, child_2_layout.height());
 
-	assert_eq!(0.0, child_2_child_0_layout.left);
-	assert_eq!(0.0, child_2_child_0_layout.top);
-	assert_eq!(50.0, child_2_child_0_layout.width);
-	assert_eq!(10.0, child_2_child_0_layout.height);
+	assert_eq!(0.0, child_2_child_0_layout.left());
+	assert_eq!(0.0, child_2_child_0_layout.top());
+	assert_eq!(50.0, child_2_child_0_layout.width());
+	assert_eq!(10.0, child_2_child_0_layout.height());
 
-	assert_eq!(50.0, child_3_layout.left);
-	assert_eq!(60.0, child_3_layout.top);
-	assert_eq!(50.0, child_3_layout.width);
-	assert_eq!(50.0, child_3_layout.height);
+	assert_eq!(50.0, child_3_layout.left());
+	assert_eq!(60.0, child_3_layout.top());
+	assert_eq!(50.0, child_3_layout.width());
+	assert_eq!(50.0, child_3_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
@@ -1503,40 +1503,40 @@ fn test_align_baseline_multiline() {
 	let child_2_child_0_layout = root_child_2_child_0.get_layout();
 	let child_3_layout = root_child_3.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(50.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(50.0, child_0_layout.height);
+	assert_eq!(50.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(50.0, child_0_layout.height());
 
-	assert_eq!(0.0, child_1_layout.left);
-	assert_eq!(40.0, child_1_layout.top);
-	assert_eq!(50.0, child_1_layout.width);
-	assert_eq!(20.0, child_1_layout.height);
+	assert_eq!(0.0, child_1_layout.left());
+	assert_eq!(40.0, child_1_layout.top());
+	assert_eq!(50.0, child_1_layout.width());
+	assert_eq!(20.0, child_1_layout.height());
 
-	assert_eq!(0.0, child_1_child_0_layout.left);
-	assert_eq!(0.0, child_1_child_0_layout.top);
-	assert_eq!(50.0, child_1_child_0_layout.width);
-	assert_eq!(10.0, child_1_child_0_layout.height);
+	assert_eq!(0.0, child_1_child_0_layout.left());
+	assert_eq!(0.0, child_1_child_0_layout.top());
+	assert_eq!(50.0, child_1_child_0_layout.width());
+	assert_eq!(10.0, child_1_child_0_layout.height());
 
-	assert_eq!(50.0, child_2_layout.left);
-	assert_eq!(100.0, child_2_layout.top);
-	assert_eq!(50.0, child_2_layout.width);
-	assert_eq!(20.0, child_2_layout.height);
+	assert_eq!(50.0, child_2_layout.left());
+	assert_eq!(100.0, child_2_layout.top());
+	assert_eq!(50.0, child_2_layout.width());
+	assert_eq!(20.0, child_2_layout.height());
 
-	assert_eq!(0.0, child_2_child_0_layout.left);
-	assert_eq!(0.0, child_2_child_0_layout.top);
-	assert_eq!(50.0, child_2_child_0_layout.width);
-	assert_eq!(10.0, child_2_child_0_layout.height);
+	assert_eq!(0.0, child_2_child_0_layout.left());
+	assert_eq!(0.0, child_2_child_0_layout.top());
+	assert_eq!(50.0, child_2_child_0_layout.width());
+	assert_eq!(10.0, child_2_child_0_layout.height());
 
-	assert_eq!(0.0, child_3_layout.left);
-	assert_eq!(60.0, child_3_layout.top);
-	assert_eq!(50.0, child_3_layout.width);
-	assert_eq!(50.0, child_3_layout.height);
+	assert_eq!(0.0, child_3_layout.left());
+	assert_eq!(60.0, child_3_layout.top());
+	assert_eq!(50.0, child_3_layout.width());
+	assert_eq!(50.0, child_3_layout.height());
 }
 
 #[test]
@@ -1609,40 +1609,40 @@ fn test_align_baseline_multiline_column() {
 	let child_2_child_0_layout = root_child_2_child_0.get_layout();
 	let child_3_layout = root_child_3.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(50.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(50.0, child_0_layout.height());
 
-	assert_eq!(0.0, child_1_layout.left);
-	assert_eq!(50.0, child_1_layout.top);
-	assert_eq!(30.0, child_1_layout.width);
-	assert_eq!(50.0, child_1_layout.height);
+	assert_eq!(0.0, child_1_layout.left());
+	assert_eq!(50.0, child_1_layout.top());
+	assert_eq!(30.0, child_1_layout.width());
+	assert_eq!(50.0, child_1_layout.height());
 
-	assert_eq!(0.0, child_1_child_0_layout.left);
-	assert_eq!(0.0, child_1_child_0_layout.top);
-	assert_eq!(20.0, child_1_child_0_layout.width);
-	assert_eq!(20.0, child_1_child_0_layout.height);
+	assert_eq!(0.0, child_1_child_0_layout.left());
+	assert_eq!(0.0, child_1_child_0_layout.top());
+	assert_eq!(20.0, child_1_child_0_layout.width());
+	assert_eq!(20.0, child_1_child_0_layout.height());
 
-	assert_eq!(50.0, child_2_layout.left);
-	assert_eq!(0.0, child_2_layout.top);
-	assert_eq!(40.0, child_2_layout.width);
-	assert_eq!(70.0, child_2_layout.height);
+	assert_eq!(50.0, child_2_layout.left());
+	assert_eq!(0.0, child_2_layout.top());
+	assert_eq!(40.0, child_2_layout.width());
+	assert_eq!(70.0, child_2_layout.height());
 
-	assert_eq!(0.0, child_2_child_0_layout.left);
-	assert_eq!(0.0, child_2_child_0_layout.top);
-	assert_eq!(10.0, child_2_child_0_layout.width);
-	assert_eq!(10.0, child_2_child_0_layout.height);
+	assert_eq!(0.0, child_2_child_0_layout.left());
+	assert_eq!(0.0, child_2_child_0_layout.top());
+	assert_eq!(10.0, child_2_child_0_layout.width());
+	assert_eq!(10.0, child_2_child_0_layout.height());
 
-	assert_eq!(50.0, child_3_layout.left);
-	assert_eq!(70.0, child_3_layout.top);
-	assert_eq!(50.0, child_3_layout.width);
-	assert_eq!(20.0, child_3_layout.height);
+	assert_eq!(50.0, child_3_layout.left());
+	assert_eq!(70.0, child_3_layout.top());
+	assert_eq!(50.0, child_3_layout.width());
+	assert_eq!(20.0, child_3_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
@@ -1654,40 +1654,40 @@ fn test_align_baseline_multiline_column() {
 	let child_2_child_0_layout = root_child_2_child_0.get_layout();
 	let child_3_layout = root_child_3.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(50.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(50.0, child_0_layout.height);
+	assert_eq!(50.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(50.0, child_0_layout.height());
 
-	assert_eq!(70.0, child_1_layout.left);
-	assert_eq!(50.0, child_1_layout.top);
-	assert_eq!(30.0, child_1_layout.width);
-	assert_eq!(50.0, child_1_layout.height);
+	assert_eq!(70.0, child_1_layout.left());
+	assert_eq!(50.0, child_1_layout.top());
+	assert_eq!(30.0, child_1_layout.width());
+	assert_eq!(50.0, child_1_layout.height());
 
-	assert_eq!(10.0, child_1_child_0_layout.left);
-	assert_eq!(0.0, child_1_child_0_layout.top);
-	assert_eq!(20.0, child_1_child_0_layout.width);
-	assert_eq!(20.0, child_1_child_0_layout.height);
+	assert_eq!(10.0, child_1_child_0_layout.left());
+	assert_eq!(0.0, child_1_child_0_layout.top());
+	assert_eq!(20.0, child_1_child_0_layout.width());
+	assert_eq!(20.0, child_1_child_0_layout.height());
 
-	assert_eq!(10.0, child_2_layout.left);
-	assert_eq!(0.0, child_2_layout.top);
-	assert_eq!(40.0, child_2_layout.width);
-	assert_eq!(70.0, child_2_layout.height);
+	assert_eq!(10.0, child_2_layout.left());
+	assert_eq!(0.0, child_2_layout.top());
+	assert_eq!(40.0, child_2_layout.width());
+	assert_eq!(70.0, child_2_layout.height());
 
-	assert_eq!(30.0, child_2_child_0_layout.left);
-	assert_eq!(0.0, child_2_child_0_layout.top);
-	assert_eq!(10.0, child_2_child_0_layout.width);
-	assert_eq!(10.0, child_2_child_0_layout.height);
+	assert_eq!(30.0, child_2_child_0_layout.left());
+	assert_eq!(0.0, child_2_child_0_layout.top());
+	assert_eq!(10.0, child_2_child_0_layout.width());
+	assert_eq!(10.0, child_2_child_0_layout.height());
 
-	assert_eq!(0.0, child_3_layout.left);
-	assert_eq!(70.0, child_3_layout.top);
-	assert_eq!(50.0, child_3_layout.width);
-	assert_eq!(20.0, child_3_layout.height);
+	assert_eq!(0.0, child_3_layout.left());
+	assert_eq!(70.0, child_3_layout.top());
+	assert_eq!(50.0, child_3_layout.width());
+	assert_eq!(20.0, child_3_layout.height());
 }
 
 #[test]
@@ -1760,40 +1760,40 @@ fn test_align_baseline_multiline_column2() {
 	let child_2_child_0_layout = root_child_2_child_0.get_layout();
 	let child_3_layout = root_child_3.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(50.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(50.0, child_0_layout.height());
 
-	assert_eq!(0.0, child_1_layout.left);
-	assert_eq!(50.0, child_1_layout.top);
-	assert_eq!(30.0, child_1_layout.width);
-	assert_eq!(50.0, child_1_layout.height);
+	assert_eq!(0.0, child_1_layout.left());
+	assert_eq!(50.0, child_1_layout.top());
+	assert_eq!(30.0, child_1_layout.width());
+	assert_eq!(50.0, child_1_layout.height());
 
-	assert_eq!(0.0, child_1_child_0_layout.left);
-	assert_eq!(0.0, child_1_child_0_layout.top);
-	assert_eq!(20.0, child_1_child_0_layout.width);
-	assert_eq!(20.0, child_1_child_0_layout.height);
+	assert_eq!(0.0, child_1_child_0_layout.left());
+	assert_eq!(0.0, child_1_child_0_layout.top());
+	assert_eq!(20.0, child_1_child_0_layout.width());
+	assert_eq!(20.0, child_1_child_0_layout.height());
 
-	assert_eq!(50.0, child_2_layout.left);
-	assert_eq!(0.0, child_2_layout.top);
-	assert_eq!(40.0, child_2_layout.width);
-	assert_eq!(70.0, child_2_layout.height);
+	assert_eq!(50.0, child_2_layout.left());
+	assert_eq!(0.0, child_2_layout.top());
+	assert_eq!(40.0, child_2_layout.width());
+	assert_eq!(70.0, child_2_layout.height());
 
-	assert_eq!(0.0, child_2_child_0_layout.left);
-	assert_eq!(0.0, child_2_child_0_layout.top);
-	assert_eq!(10.0, child_2_child_0_layout.width);
-	assert_eq!(10.0, child_2_child_0_layout.height);
+	assert_eq!(0.0, child_2_child_0_layout.left());
+	assert_eq!(0.0, child_2_child_0_layout.top());
+	assert_eq!(10.0, child_2_child_0_layout.width());
+	assert_eq!(10.0, child_2_child_0_layout.height());
 
-	assert_eq!(50.0, child_3_layout.left);
-	assert_eq!(70.0, child_3_layout.top);
-	assert_eq!(50.0, child_3_layout.width);
-	assert_eq!(20.0, child_3_layout.height);
+	assert_eq!(50.0, child_3_layout.left());
+	assert_eq!(70.0, child_3_layout.top());
+	assert_eq!(50.0, child_3_layout.width());
+	assert_eq!(20.0, child_3_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
@@ -1805,40 +1805,40 @@ fn test_align_baseline_multiline_column2() {
 	let child_2_child_0_layout = root_child_2_child_0.get_layout();
 	let child_3_layout = root_child_3.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(50.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(50.0, child_0_layout.height);
+	assert_eq!(50.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(50.0, child_0_layout.height());
 
-	assert_eq!(70.0, child_1_layout.left);
-	assert_eq!(50.0, child_1_layout.top);
-	assert_eq!(30.0, child_1_layout.width);
-	assert_eq!(50.0, child_1_layout.height);
+	assert_eq!(70.0, child_1_layout.left());
+	assert_eq!(50.0, child_1_layout.top());
+	assert_eq!(30.0, child_1_layout.width());
+	assert_eq!(50.0, child_1_layout.height());
 
-	assert_eq!(10.0, child_1_child_0_layout.left);
-	assert_eq!(0.0, child_1_child_0_layout.top);
-	assert_eq!(20.0, child_1_child_0_layout.width);
-	assert_eq!(20.0, child_1_child_0_layout.height);
+	assert_eq!(10.0, child_1_child_0_layout.left());
+	assert_eq!(0.0, child_1_child_0_layout.top());
+	assert_eq!(20.0, child_1_child_0_layout.width());
+	assert_eq!(20.0, child_1_child_0_layout.height());
 
-	assert_eq!(10.0, child_2_layout.left);
-	assert_eq!(0.0, child_2_layout.top);
-	assert_eq!(40.0, child_2_layout.width);
-	assert_eq!(70.0, child_2_layout.height);
+	assert_eq!(10.0, child_2_layout.left());
+	assert_eq!(0.0, child_2_layout.top());
+	assert_eq!(40.0, child_2_layout.width());
+	assert_eq!(70.0, child_2_layout.height());
 
-	assert_eq!(30.0, child_2_child_0_layout.left);
-	assert_eq!(0.0, child_2_child_0_layout.top);
-	assert_eq!(10.0, child_2_child_0_layout.width);
-	assert_eq!(10.0, child_2_child_0_layout.height);
+	assert_eq!(30.0, child_2_child_0_layout.left());
+	assert_eq!(0.0, child_2_child_0_layout.top());
+	assert_eq!(10.0, child_2_child_0_layout.width());
+	assert_eq!(10.0, child_2_child_0_layout.height());
 
-	assert_eq!(0.0, child_3_layout.left);
-	assert_eq!(70.0, child_3_layout.top);
-	assert_eq!(50.0, child_3_layout.width);
-	assert_eq!(20.0, child_3_layout.height);
+	assert_eq!(0.0, child_3_layout.left());
+	assert_eq!(70.0, child_3_layout.top());
+	assert_eq!(50.0, child_3_layout.width());
+	assert_eq!(20.0, child_3_layout.height());
 }
 
 #[test]
@@ -1912,40 +1912,40 @@ fn test_align_baseline_multiline_row_and_column() {
 	let child_2_child_0_layout = root_child_2_child_0.get_layout();
 	let child_3_layout = root_child_3.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(50.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(50.0, child_0_layout.height());
 
-	assert_eq!(50.0, child_1_layout.left);
-	assert_eq!(40.0, child_1_layout.top);
-	assert_eq!(50.0, child_1_layout.width);
-	assert_eq!(50.0, child_1_layout.height);
+	assert_eq!(50.0, child_1_layout.left());
+	assert_eq!(40.0, child_1_layout.top());
+	assert_eq!(50.0, child_1_layout.width());
+	assert_eq!(50.0, child_1_layout.height());
 
-	assert_eq!(0.0, child_1_child_0_layout.left);
-	assert_eq!(0.0, child_1_child_0_layout.top);
-	assert_eq!(50.0, child_1_child_0_layout.width);
-	assert_eq!(10.0, child_1_child_0_layout.height);
+	assert_eq!(0.0, child_1_child_0_layout.left());
+	assert_eq!(0.0, child_1_child_0_layout.top());
+	assert_eq!(50.0, child_1_child_0_layout.width());
+	assert_eq!(10.0, child_1_child_0_layout.height());
 
-	assert_eq!(0.0, child_2_layout.left);
-	assert_eq!(100.0, child_2_layout.top);
-	assert_eq!(50.0, child_2_layout.width);
-	assert_eq!(20.0, child_2_layout.height);
+	assert_eq!(0.0, child_2_layout.left());
+	assert_eq!(100.0, child_2_layout.top());
+	assert_eq!(50.0, child_2_layout.width());
+	assert_eq!(20.0, child_2_layout.height());
 
-	assert_eq!(0.0, child_2_child_0_layout.left);
-	assert_eq!(0.0, child_2_child_0_layout.top);
-	assert_eq!(50.0, child_2_child_0_layout.width);
-	assert_eq!(10.0, child_2_child_0_layout.height);
+	assert_eq!(0.0, child_2_child_0_layout.left());
+	assert_eq!(0.0, child_2_child_0_layout.top());
+	assert_eq!(50.0, child_2_child_0_layout.width());
+	assert_eq!(10.0, child_2_child_0_layout.height());
 
-	assert_eq!(50.0, child_3_layout.left);
-	assert_eq!(90.0, child_3_layout.top);
-	assert_eq!(50.0, child_3_layout.width);
-	assert_eq!(20.0, child_3_layout.height);
+	assert_eq!(50.0, child_3_layout.left());
+	assert_eq!(90.0, child_3_layout.top());
+	assert_eq!(50.0, child_3_layout.width());
+	assert_eq!(20.0, child_3_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
@@ -1957,40 +1957,40 @@ fn test_align_baseline_multiline_row_and_column() {
 	let child_2_child_0_layout = root_child_2_child_0.get_layout();
 	let child_3_layout = root_child_3.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(50.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(50.0, child_0_layout.height);
+	assert_eq!(50.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(50.0, child_0_layout.height());
 
-	assert_eq!(0.0, child_1_layout.left);
-	assert_eq!(40.0, child_1_layout.top);
-	assert_eq!(50.0, child_1_layout.width);
-	assert_eq!(50.0, child_1_layout.height);
+	assert_eq!(0.0, child_1_layout.left());
+	assert_eq!(40.0, child_1_layout.top());
+	assert_eq!(50.0, child_1_layout.width());
+	assert_eq!(50.0, child_1_layout.height());
 
-	assert_eq!(0.0, child_1_child_0_layout.left);
-	assert_eq!(0.0, child_1_child_0_layout.top);
-	assert_eq!(50.0, child_1_child_0_layout.width);
-	assert_eq!(10.0, child_1_child_0_layout.height);
+	assert_eq!(0.0, child_1_child_0_layout.left());
+	assert_eq!(0.0, child_1_child_0_layout.top());
+	assert_eq!(50.0, child_1_child_0_layout.width());
+	assert_eq!(10.0, child_1_child_0_layout.height());
 
-	assert_eq!(50.0, child_2_layout.left);
-	assert_eq!(100.0, child_2_layout.top);
-	assert_eq!(50.0, child_2_layout.width);
-	assert_eq!(20.0, child_2_layout.height);
+	assert_eq!(50.0, child_2_layout.left());
+	assert_eq!(100.0, child_2_layout.top());
+	assert_eq!(50.0, child_2_layout.width());
+	assert_eq!(20.0, child_2_layout.height());
 
-	assert_eq!(0.0, child_2_child_0_layout.left);
-	assert_eq!(0.0, child_2_child_0_layout.top);
-	assert_eq!(50.0, child_2_child_0_layout.width);
-	assert_eq!(10.0, child_2_child_0_layout.height);
+	assert_eq!(0.0, child_2_child_0_layout.left());
+	assert_eq!(0.0, child_2_child_0_layout.top());
+	assert_eq!(50.0, child_2_child_0_layout.width());
+	assert_eq!(10.0, child_2_child_0_layout.height());
 
-	assert_eq!(0.0, child_3_layout.left);
-	assert_eq!(90.0, child_3_layout.top);
-	assert_eq!(50.0, child_3_layout.width);
-	assert_eq!(20.0, child_3_layout.height);
+	assert_eq!(0.0, child_3_layout.left());
+	assert_eq!(90.0, child_3_layout.top());
+	assert_eq!(50.0, child_3_layout.width());
+	assert_eq!(20.0, child_3_layout.height());
 }
 
 #[test]
@@ -2026,20 +2026,20 @@ fn test_align_items_center_child_with_margin_bigger_than_parent() {
 	let child_0_layout = root_child_0.get_layout();
 	let child_0_child_0_layout = root_child_0_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(52.0, root_layout.width);
-	assert_eq!(52.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(52.0, root_layout.width());
+	assert_eq!(52.0, root_layout.height());
 
-	assert_eq!(-10.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(72.0, child_0_layout.width);
-	assert_eq!(52.0, child_0_layout.height);
+	assert_eq!(-10.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(72.0, child_0_layout.width());
+	assert_eq!(52.0, child_0_layout.height());
 
-	assert_eq!(10.0, child_0_child_0_layout.left);
-	assert_eq!(0.0, child_0_child_0_layout.top);
-	assert_eq!(52.0, child_0_child_0_layout.width);
-	assert_eq!(52.0, child_0_child_0_layout.height);
+	assert_eq!(10.0, child_0_child_0_layout.left());
+	assert_eq!(0.0, child_0_child_0_layout.top());
+	assert_eq!(52.0, child_0_child_0_layout.width());
+	assert_eq!(52.0, child_0_child_0_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
@@ -2047,20 +2047,20 @@ fn test_align_items_center_child_with_margin_bigger_than_parent() {
 	let child_0_layout = root_child_0.get_layout();
 	let child_0_child_0_layout = root_child_0_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(52.0, root_layout.width);
-	assert_eq!(52.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(52.0, root_layout.width());
+	assert_eq!(52.0, root_layout.height());
 
-	assert_eq!(-10.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(72.0, child_0_layout.width);
-	assert_eq!(52.0, child_0_layout.height);
+	assert_eq!(-10.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(72.0, child_0_layout.width());
+	assert_eq!(52.0, child_0_layout.height());
 
-	assert_eq!(10.0, child_0_child_0_layout.left);
-	assert_eq!(0.0, child_0_child_0_layout.top);
-	assert_eq!(52.0, child_0_child_0_layout.width);
-	assert_eq!(52.0, child_0_child_0_layout.height);
+	assert_eq!(10.0, child_0_child_0_layout.left());
+	assert_eq!(0.0, child_0_child_0_layout.top());
+	assert_eq!(52.0, child_0_child_0_layout.width());
+	assert_eq!(52.0, child_0_child_0_layout.height());
 }
 
 #[test]
@@ -2096,20 +2096,20 @@ fn test_align_items_flex_end_child_with_margin_bigger_than_parent() {
 	let child_0_layout = root_child_0.get_layout();
 	let child_0_child_0_layout = root_child_0_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(52.0, root_layout.width);
-	assert_eq!(52.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(52.0, root_layout.width());
+	assert_eq!(52.0, root_layout.height());
 
-	assert_eq!(-10.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(72.0, child_0_layout.width);
-	assert_eq!(52.0, child_0_layout.height);
+	assert_eq!(-10.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(72.0, child_0_layout.width());
+	assert_eq!(52.0, child_0_layout.height());
 
-	assert_eq!(10.0, child_0_child_0_layout.left);
-	assert_eq!(0.0, child_0_child_0_layout.top);
-	assert_eq!(52.0, child_0_child_0_layout.width);
-	assert_eq!(52.0, child_0_child_0_layout.height);
+	assert_eq!(10.0, child_0_child_0_layout.left());
+	assert_eq!(0.0, child_0_child_0_layout.top());
+	assert_eq!(52.0, child_0_child_0_layout.width());
+	assert_eq!(52.0, child_0_child_0_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
@@ -2117,20 +2117,20 @@ fn test_align_items_flex_end_child_with_margin_bigger_than_parent() {
 	let child_0_layout = root_child_0.get_layout();
 	let child_0_child_0_layout = root_child_0_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(52.0, root_layout.width);
-	assert_eq!(52.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(52.0, root_layout.width());
+	assert_eq!(52.0, root_layout.height());
 
-	assert_eq!(-10.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(72.0, child_0_layout.width);
-	assert_eq!(52.0, child_0_layout.height);
+	assert_eq!(-10.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(72.0, child_0_layout.width());
+	assert_eq!(52.0, child_0_layout.height());
 
-	assert_eq!(10.0, child_0_child_0_layout.left);
-	assert_eq!(0.0, child_0_child_0_layout.top);
-	assert_eq!(52.0, child_0_child_0_layout.width);
-	assert_eq!(52.0, child_0_child_0_layout.height);
+	assert_eq!(10.0, child_0_child_0_layout.left());
+	assert_eq!(0.0, child_0_child_0_layout.top());
+	assert_eq!(52.0, child_0_child_0_layout.width());
+	assert_eq!(52.0, child_0_child_0_layout.height());
 }
 
 #[test]
@@ -2164,20 +2164,20 @@ fn test_align_items_center_child_without_margin_bigger_than_parent() {
 	let child_0_layout = root_child_0.get_layout();
 	let child_0_child_0_layout = root_child_0_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(52.0, root_layout.width);
-	assert_eq!(52.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(52.0, root_layout.width());
+	assert_eq!(52.0, root_layout.height());
 
-	assert_eq!(-10.0, child_0_layout.left);
-	assert_eq!(-10.0, child_0_layout.top);
-	assert_eq!(72.0, child_0_layout.width);
-	assert_eq!(72.0, child_0_layout.height);
+	assert_eq!(-10.0, child_0_layout.left());
+	assert_eq!(-10.0, child_0_layout.top());
+	assert_eq!(72.0, child_0_layout.width());
+	assert_eq!(72.0, child_0_layout.height());
 
-	assert_eq!(0.0, child_0_child_0_layout.left);
-	assert_eq!(0.0, child_0_child_0_layout.top);
-	assert_eq!(72.0, child_0_child_0_layout.width);
-	assert_eq!(72.0, child_0_child_0_layout.height);
+	assert_eq!(0.0, child_0_child_0_layout.left());
+	assert_eq!(0.0, child_0_child_0_layout.top());
+	assert_eq!(72.0, child_0_child_0_layout.width());
+	assert_eq!(72.0, child_0_child_0_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
@@ -2185,20 +2185,20 @@ fn test_align_items_center_child_without_margin_bigger_than_parent() {
 	let child_0_layout = root_child_0.get_layout();
 	let child_0_child_0_layout = root_child_0_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(52.0, root_layout.width);
-	assert_eq!(52.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(52.0, root_layout.width());
+	assert_eq!(52.0, root_layout.height());
 
-	assert_eq!(-10.0, child_0_layout.left);
-	assert_eq!(-10.0, child_0_layout.top);
-	assert_eq!(72.0, child_0_layout.width);
-	assert_eq!(72.0, child_0_layout.height);
+	assert_eq!(-10.0, child_0_layout.left());
+	assert_eq!(-10.0, child_0_layout.top());
+	assert_eq!(72.0, child_0_layout.width());
+	assert_eq!(72.0, child_0_layout.height());
 
-	assert_eq!(0.0, child_0_child_0_layout.left);
-	assert_eq!(0.0, child_0_child_0_layout.top);
-	assert_eq!(72.0, child_0_child_0_layout.width);
-	assert_eq!(72.0, child_0_child_0_layout.height);
+	assert_eq!(0.0, child_0_child_0_layout.left());
+	assert_eq!(0.0, child_0_child_0_layout.top());
+	assert_eq!(72.0, child_0_child_0_layout.width());
+	assert_eq!(72.0, child_0_child_0_layout.height());
 }
 
 #[test]
@@ -2232,20 +2232,20 @@ fn test_align_items_flex_end_child_without_margin_bigger_than_parent() {
 	let child_0_layout = root_child_0.get_layout();
 	let child_0_child_0_layout = root_child_0_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(52.0, root_layout.width);
-	assert_eq!(52.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(52.0, root_layout.width());
+	assert_eq!(52.0, root_layout.height());
 
-	assert_eq!(-10.0, child_0_layout.left);
-	assert_eq!(-10.0, child_0_layout.top);
-	assert_eq!(72.0, child_0_layout.width);
-	assert_eq!(72.0, child_0_layout.height);
+	assert_eq!(-10.0, child_0_layout.left());
+	assert_eq!(-10.0, child_0_layout.top());
+	assert_eq!(72.0, child_0_layout.width());
+	assert_eq!(72.0, child_0_layout.height());
 
-	assert_eq!(0.0, child_0_child_0_layout.left);
-	assert_eq!(0.0, child_0_child_0_layout.top);
-	assert_eq!(72.0, child_0_child_0_layout.width);
-	assert_eq!(72.0, child_0_child_0_layout.height);
+	assert_eq!(0.0, child_0_child_0_layout.left());
+	assert_eq!(0.0, child_0_child_0_layout.top());
+	assert_eq!(72.0, child_0_child_0_layout.width());
+	assert_eq!(72.0, child_0_child_0_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
@@ -2253,20 +2253,20 @@ fn test_align_items_flex_end_child_without_margin_bigger_than_parent() {
 	let child_0_layout = root_child_0.get_layout();
 	let child_0_child_0_layout = root_child_0_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(52.0, root_layout.width);
-	assert_eq!(52.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(52.0, root_layout.width());
+	assert_eq!(52.0, root_layout.height());
 
-	assert_eq!(-10.0, child_0_layout.left);
-	assert_eq!(-10.0, child_0_layout.top);
-	assert_eq!(72.0, child_0_layout.width);
-	assert_eq!(72.0, child_0_layout.height);
+	assert_eq!(-10.0, child_0_layout.left());
+	assert_eq!(-10.0, child_0_layout.top());
+	assert_eq!(72.0, child_0_layout.width());
+	assert_eq!(72.0, child_0_layout.height());
 
-	assert_eq!(0.0, child_0_child_0_layout.left);
-	assert_eq!(0.0, child_0_child_0_layout.top);
-	assert_eq!(72.0, child_0_child_0_layout.width);
-	assert_eq!(72.0, child_0_child_0_layout.height);
+	assert_eq!(0.0, child_0_child_0_layout.left());
+	assert_eq!(0.0, child_0_child_0_layout.top());
+	assert_eq!(72.0, child_0_child_0_layout.width());
+	assert_eq!(72.0, child_0_child_0_layout.height());
 }
 
 #[test]
@@ -2310,25 +2310,25 @@ fn test_align_center_should_size_based_on_content() {
 	let child_0_child_0_layout = root_child_0_child_0.get_layout();
 	let child_0_child_0_child_0_layout = root_child_0_child_0_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(20.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(20.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(40.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(20.0, child_0_layout.width);
-	assert_eq!(20.0, child_0_layout.height);
+	assert_eq!(40.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(20.0, child_0_layout.width());
+	assert_eq!(20.0, child_0_layout.height());
 
-	assert_eq!(0.0, child_0_child_0_layout.left);
-	assert_eq!(0.0, child_0_child_0_layout.top);
-	assert_eq!(20.0, child_0_child_0_layout.width);
-	assert_eq!(20.0, child_0_child_0_layout.height);
+	assert_eq!(0.0, child_0_child_0_layout.left());
+	assert_eq!(0.0, child_0_child_0_layout.top());
+	assert_eq!(20.0, child_0_child_0_layout.width());
+	assert_eq!(20.0, child_0_child_0_layout.height());
 
-	assert_eq!(0.0, child_0_child_0_child_0_layout.left);
-	assert_eq!(0.0, child_0_child_0_child_0_layout.top);
-	assert_eq!(20.0, child_0_child_0_child_0_layout.width);
-	assert_eq!(20.0, child_0_child_0_child_0_layout.height);
+	assert_eq!(0.0, child_0_child_0_child_0_layout.left());
+	assert_eq!(0.0, child_0_child_0_child_0_layout.top());
+	assert_eq!(20.0, child_0_child_0_child_0_layout.width());
+	assert_eq!(20.0, child_0_child_0_child_0_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
@@ -2337,25 +2337,25 @@ fn test_align_center_should_size_based_on_content() {
 	let child_0_child_0_layout = root_child_0_child_0.get_layout();
 	let child_0_child_0_child_0_layout = root_child_0_child_0_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(20.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(20.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(40.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(20.0, child_0_layout.width);
-	assert_eq!(20.0, child_0_layout.height);
+	assert_eq!(40.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(20.0, child_0_layout.width());
+	assert_eq!(20.0, child_0_layout.height());
 
-	assert_eq!(0.0, child_0_child_0_layout.left);
-	assert_eq!(0.0, child_0_child_0_layout.top);
-	assert_eq!(20.0, child_0_child_0_layout.width);
-	assert_eq!(20.0, child_0_child_0_layout.height);
+	assert_eq!(0.0, child_0_child_0_layout.left());
+	assert_eq!(0.0, child_0_child_0_layout.top());
+	assert_eq!(20.0, child_0_child_0_layout.width());
+	assert_eq!(20.0, child_0_child_0_layout.height());
 
-	assert_eq!(0.0, child_0_child_0_child_0_layout.left);
-	assert_eq!(0.0, child_0_child_0_child_0_layout.top);
-	assert_eq!(20.0, child_0_child_0_child_0_layout.width);
-	assert_eq!(20.0, child_0_child_0_child_0_layout.height);
+	assert_eq!(0.0, child_0_child_0_child_0_layout.left());
+	assert_eq!(0.0, child_0_child_0_child_0_layout.top());
+	assert_eq!(20.0, child_0_child_0_child_0_layout.width());
+	assert_eq!(20.0, child_0_child_0_child_0_layout.height());
 }
 
 #[test]
@@ -2398,25 +2398,25 @@ fn test_align_strech_should_size_based_on_parent() {
 	let child_0_child_0_layout = root_child_0_child_0.get_layout();
 	let child_0_child_0_child_0_layout = root_child_0_child_0_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(20.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(20.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(100.0, child_0_layout.width);
-	assert_eq!(20.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(100.0, child_0_layout.width());
+	assert_eq!(20.0, child_0_layout.height());
 
-	assert_eq!(0.0, child_0_child_0_layout.left);
-	assert_eq!(0.0, child_0_child_0_layout.top);
-	assert_eq!(100.0, child_0_child_0_layout.width);
-	assert_eq!(20.0, child_0_child_0_layout.height);
+	assert_eq!(0.0, child_0_child_0_layout.left());
+	assert_eq!(0.0, child_0_child_0_layout.top());
+	assert_eq!(100.0, child_0_child_0_layout.width());
+	assert_eq!(20.0, child_0_child_0_layout.height());
 
-	assert_eq!(0.0, child_0_child_0_child_0_layout.left);
-	assert_eq!(0.0, child_0_child_0_child_0_layout.top);
-	assert_eq!(20.0, child_0_child_0_child_0_layout.width);
-	assert_eq!(20.0, child_0_child_0_child_0_layout.height);
+	assert_eq!(0.0, child_0_child_0_child_0_layout.left());
+	assert_eq!(0.0, child_0_child_0_child_0_layout.top());
+	assert_eq!(20.0, child_0_child_0_child_0_layout.width());
+	assert_eq!(20.0, child_0_child_0_child_0_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
@@ -2425,23 +2425,23 @@ fn test_align_strech_should_size_based_on_parent() {
 	let child_0_child_0_layout = root_child_0_child_0.get_layout();
 	let child_0_child_0_child_0_layout = root_child_0_child_0_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(20.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(20.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(100.0, child_0_layout.width);
-	assert_eq!(20.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(100.0, child_0_layout.width());
+	assert_eq!(20.0, child_0_layout.height());
 
-	assert_eq!(0.0, child_0_child_0_layout.left);
-	assert_eq!(0.0, child_0_child_0_layout.top);
-	assert_eq!(100.0, child_0_child_0_layout.width);
-	assert_eq!(20.0, child_0_child_0_layout.height);
+	assert_eq!(0.0, child_0_child_0_layout.left());
+	assert_eq!(0.0, child_0_child_0_layout.top());
+	assert_eq!(100.0, child_0_child_0_layout.width());
+	assert_eq!(20.0, child_0_child_0_layout.height());
 
-	assert_eq!(80.0, child_0_child_0_child_0_layout.left);
-	assert_eq!(0.0, child_0_child_0_child_0_layout.top);
-	assert_eq!(20.0, child_0_child_0_child_0_layout.width);
-	assert_eq!(20.0, child_0_child_0_child_0_layout.height);
+	assert_eq!(80.0, child_0_child_0_child_0_layout.left());
+	assert_eq!(0.0, child_0_child_0_child_0_layout.top());
+	assert_eq!(20.0, child_0_child_0_child_0_layout.width());
+	assert_eq!(20.0, child_0_child_0_child_0_layout.height());
 }

--- a/tests/align_self_test.rs
+++ b/tests/align_self_test.rs
@@ -27,30 +27,30 @@ fn test_align_self_center() {
 	let root_layout = root.get_layout();
 	let child_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(45.0, child_layout.left);
-	assert_eq!(0.0, child_layout.top);
-	assert_eq!(10.0, child_layout.width);
-	assert_eq!(10.0, child_layout.height);
+	assert_eq!(45.0, child_layout.left());
+	assert_eq!(0.0, child_layout.top());
+	assert_eq!(10.0, child_layout.width());
+	assert_eq!(10.0, child_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
 	let root_layout = root.get_layout();
 	let child_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(45.0, child_layout.left);
-	assert_eq!(0.0, child_layout.top);
-	assert_eq!(10.0, child_layout.width);
-	assert_eq!(10.0, child_layout.height);
+	assert_eq!(45.0, child_layout.left());
+	assert_eq!(0.0, child_layout.top());
+	assert_eq!(10.0, child_layout.width());
+	assert_eq!(10.0, child_layout.height());
 }
 
 #[test]
@@ -76,30 +76,30 @@ fn test_align_self_flex_end() {
 	let root_layout = root.get_layout();
 	let child_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(90.0, child_layout.left);
-	assert_eq!(0.0, child_layout.top);
-	assert_eq!(10.0, child_layout.width);
-	assert_eq!(10.0, child_layout.height);
+	assert_eq!(90.0, child_layout.left());
+	assert_eq!(0.0, child_layout.top());
+	assert_eq!(10.0, child_layout.width());
+	assert_eq!(10.0, child_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
 	let root_layout = root.get_layout();
 	let child_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_layout.left);
-	assert_eq!(0.0, child_layout.top);
-	assert_eq!(10.0, child_layout.width);
-	assert_eq!(10.0, child_layout.height);
+	assert_eq!(0.0, child_layout.left());
+	assert_eq!(0.0, child_layout.top());
+	assert_eq!(10.0, child_layout.width());
+	assert_eq!(10.0, child_layout.height());
 }
 
 #[test]
@@ -125,30 +125,30 @@ fn test_align_self_flex_start() {
 	let root_layout = root.get_layout();
 	let child_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_layout.left);
-	assert_eq!(0.0, child_layout.top);
-	assert_eq!(10.0, child_layout.width);
-	assert_eq!(10.0, child_layout.height);
+	assert_eq!(0.0, child_layout.left());
+	assert_eq!(0.0, child_layout.top());
+	assert_eq!(10.0, child_layout.width());
+	assert_eq!(10.0, child_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
 	let root_layout = root.get_layout();
 	let child_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(90.0, child_layout.left);
-	assert_eq!(0.0, child_layout.top);
-	assert_eq!(10.0, child_layout.width);
-	assert_eq!(10.0, child_layout.height);
+	assert_eq!(90.0, child_layout.left());
+	assert_eq!(0.0, child_layout.top());
+	assert_eq!(10.0, child_layout.width());
+	assert_eq!(10.0, child_layout.height());
 }
 
 #[test]
@@ -175,30 +175,30 @@ fn test_align_self_flex_end_override_flex_start() {
 	let root_layout = root.get_layout();
 	let child_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(90.0, child_layout.left);
-	assert_eq!(0.0, child_layout.top);
-	assert_eq!(10.0, child_layout.width);
-	assert_eq!(10.0, child_layout.height);
+	assert_eq!(90.0, child_layout.left());
+	assert_eq!(0.0, child_layout.top());
+	assert_eq!(10.0, child_layout.width());
+	assert_eq!(10.0, child_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
 	let root_layout = root.get_layout();
 	let child_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_layout.left);
-	assert_eq!(0.0, child_layout.top);
-	assert_eq!(10.0, child_layout.width);
-	assert_eq!(10.0, child_layout.height);
+	assert_eq!(0.0, child_layout.left());
+	assert_eq!(0.0, child_layout.top());
+	assert_eq!(10.0, child_layout.width());
+	assert_eq!(10.0, child_layout.height());
 }
 
 #[test]
@@ -245,25 +245,25 @@ fn test_align_self_baseline() {
 	let child_1_layout = root_child_1.get_layout();
 	let child_1_child_0_layout = root_child_1_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(50.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(50.0, child_0_layout.height());
 
-	assert_eq!(50.0, child_1_layout.left);
-	assert_eq!(40.0, child_1_layout.top);
-	assert_eq!(50.0, child_1_layout.width);
-	assert_eq!(20.0, child_1_layout.height);
+	assert_eq!(50.0, child_1_layout.left());
+	assert_eq!(40.0, child_1_layout.top());
+	assert_eq!(50.0, child_1_layout.width());
+	assert_eq!(20.0, child_1_layout.height());
 
-	assert_eq!(0.0, child_1_child_0_layout.left);
-	assert_eq!(0.0, child_1_child_0_layout.top);
-	assert_eq!(50.0, child_1_child_0_layout.width);
-	assert_eq!(10.0, child_1_child_0_layout.height);
+	assert_eq!(0.0, child_1_child_0_layout.left());
+	assert_eq!(0.0, child_1_child_0_layout.top());
+	assert_eq!(50.0, child_1_child_0_layout.width());
+	assert_eq!(10.0, child_1_child_0_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
@@ -272,23 +272,23 @@ fn test_align_self_baseline() {
 	let child_1_layout = root_child_1.get_layout();
 	let child_1_child_0_layout = root_child_1_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(50.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(50.0, child_0_layout.height);
+	assert_eq!(50.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(50.0, child_0_layout.height());
 
-	assert_eq!(0.0, child_1_layout.left);
-	assert_eq!(40.0, child_1_layout.top);
-	assert_eq!(50.0, child_1_layout.width);
-	assert_eq!(20.0, child_1_layout.height);
+	assert_eq!(0.0, child_1_layout.left());
+	assert_eq!(40.0, child_1_layout.top());
+	assert_eq!(50.0, child_1_layout.width());
+	assert_eq!(20.0, child_1_layout.height());
 
-	assert_eq!(0.0, child_1_child_0_layout.left);
-	assert_eq!(0.0, child_1_child_0_layout.top);
-	assert_eq!(50.0, child_1_child_0_layout.width);
-	assert_eq!(10.0, child_1_child_0_layout.height);
+	assert_eq!(0.0, child_1_child_0_layout.left());
+	assert_eq!(0.0, child_1_child_0_layout.top());
+	assert_eq!(50.0, child_1_child_0_layout.width());
+	assert_eq!(10.0, child_1_child_0_layout.height());
 }

--- a/tests/aspect_ratio_test.rs
+++ b/tests/aspect_ratio_test.rs
@@ -30,15 +30,15 @@ fn test_aspect_ratio_cross_defined() {
 	let root_layout = root.get_layout();
 	let child_0_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(50.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(50.0, child_0_layout.height());
 }
 
 #[test]
@@ -65,15 +65,15 @@ fn test_aspect_ratio_main_defined() {
 	let root_layout = root.get_layout();
 	let child_0_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(50.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(50.0, child_0_layout.height());
 }
 
 #[test]
@@ -102,15 +102,15 @@ fn test_aspect_ratio_both_dimensions_defined_row() {
 	let root_layout = root.get_layout();
 	let child_0_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(100.0, child_0_layout.width);
-	assert_eq!(100.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(100.0, child_0_layout.width());
+	assert_eq!(100.0, child_0_layout.height());
 }
 
 #[test]
@@ -138,15 +138,15 @@ fn test_aspect_ratio_both_dimensions_defined_column() {
 	let root_layout = root.get_layout();
 	let child_0_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(50.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(50.0, child_0_layout.height());
 }
 
 #[test]
@@ -169,15 +169,15 @@ fn test_aspect_ratio_align_stretch() {
 	let root_layout = root.get_layout();
 	let child_0_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(100.0, child_0_layout.width);
-	assert_eq!(100.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(100.0, child_0_layout.width());
+	assert_eq!(100.0, child_0_layout.height());
 }
 
 #[test]
@@ -205,15 +205,15 @@ fn test_aspect_ratio_flex_grow() {
 	let root_layout = root.get_layout();
 	let child_0_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(100.0, child_0_layout.width);
-	assert_eq!(100.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(100.0, child_0_layout.width());
+	assert_eq!(100.0, child_0_layout.height());
 }
 
 #[test]
@@ -241,15 +241,15 @@ fn test_aspect_ratio_flex_shrink() {
 	let root_layout = root.get_layout();
 	let child_0_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(100.0, child_0_layout.width);
-	assert_eq!(100.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(100.0, child_0_layout.width());
+	assert_eq!(100.0, child_0_layout.height());
 }
 
 #[test]
@@ -276,15 +276,15 @@ fn test_aspect_ratio_basis() {
 	let root_layout = root.get_layout();
 	let child_0_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(50.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(50.0, child_0_layout.height());
 }
 
 #[test]
@@ -313,15 +313,15 @@ fn test_aspect_ratio_absolute_layout_width_defined() {
 	let root_layout = root.get_layout();
 	let child_0_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(50.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(50.0, child_0_layout.height());
 }
 
 #[test]
@@ -350,15 +350,15 @@ fn test_aspect_ratio_absolute_layout_height_defined() {
 	let root_layout = root.get_layout();
 	let child_0_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(50.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(50.0, child_0_layout.height());
 }
 
 #[test]
@@ -386,15 +386,15 @@ fn test_aspect_ratio_with_max_cross_defined() {
 	let root_layout = root.get_layout();
 	let child_0_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(40.0, child_0_layout.width);
-	assert_eq!(50.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(40.0, child_0_layout.width());
+	assert_eq!(50.0, child_0_layout.height());
 }
 
 #[test]
@@ -422,15 +422,15 @@ fn test_aspect_ratio_with_max_main_defined() {
 	let root_layout = root.get_layout();
 	let child_0_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(40.0, child_0_layout.width);
-	assert_eq!(40.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(40.0, child_0_layout.width());
+	assert_eq!(40.0, child_0_layout.height());
 }
 
 #[test]
@@ -458,15 +458,15 @@ fn test_aspect_ratio_with_min_cross_defined() {
 	let root_layout = root.get_layout();
 	let child_0_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(40.0, child_0_layout.width);
-	assert_eq!(30.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(40.0, child_0_layout.width());
+	assert_eq!(30.0, child_0_layout.height());
 }
 
 #[test]
@@ -494,15 +494,15 @@ fn test_aspect_ratio_with_min_main_defined() {
 	let root_layout = root.get_layout();
 	let child_0_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(40.0, child_0_layout.width);
-	assert_eq!(40.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(40.0, child_0_layout.width());
+	assert_eq!(40.0, child_0_layout.height());
 }
 
 #[test]
@@ -529,15 +529,15 @@ fn test_aspect_ratio_double_cross() {
 	let root_layout = root.get_layout();
 	let child_0_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(100.0, child_0_layout.width);
-	assert_eq!(50.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(100.0, child_0_layout.width());
+	assert_eq!(50.0, child_0_layout.height());
 }
 
 #[test]
@@ -564,15 +564,15 @@ fn test_aspect_ratio_half_cross() {
 	let root_layout = root.get_layout();
 	let child_0_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(100.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(100.0, child_0_layout.height());
 }
 
 #[test]
@@ -599,15 +599,15 @@ fn test_aspect_ratio_double_main() {
 	let root_layout = root.get_layout();
 	let child_0_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(100.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(100.0, child_0_layout.height());
 }
 
 #[test]
@@ -634,15 +634,15 @@ fn test_aspect_ratio_half_main() {
 	let root_layout = root.get_layout();
 	let child_0_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(100.0, child_0_layout.width);
-	assert_eq!(50.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(100.0, child_0_layout.width());
+	assert_eq!(50.0, child_0_layout.height());
 }
 
 #[test]
@@ -690,15 +690,15 @@ fn test_aspect_ratio_with_measure_func() {
 	let root_layout = root.get_layout();
 	let child_0_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(50.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(50.0, child_0_layout.height());
 }
 
 #[test]
@@ -728,15 +728,15 @@ fn test_aspect_ratio_width_height_flex_grow_row() {
 	let root_layout = root.get_layout();
 	let child_0_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(200.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(200.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(100.0, child_0_layout.width);
-	assert_eq!(100.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(100.0, child_0_layout.width());
+	assert_eq!(100.0, child_0_layout.height());
 }
 
 #[test]
@@ -765,15 +765,15 @@ fn test_aspect_ratio_width_height_flex_grow_column() {
 	let root_layout = root.get_layout();
 	let child_0_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(200.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(200.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(100.0, child_0_layout.width);
-	assert_eq!(100.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(100.0, child_0_layout.width());
+	assert_eq!(100.0, child_0_layout.height());
 }
 
 #[test]
@@ -812,20 +812,20 @@ fn test_aspect_ratio_height_as_flex_basis() {
 	let child_0_layout = root_child_0.get_layout();
 	let child_1_layout = root_child_1.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(200.0, root_layout.width);
-	assert_eq!(200.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(200.0, root_layout.width());
+	assert_eq!(200.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(75.0, child_0_layout.width);
-	assert_eq!(75.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(75.0, child_0_layout.width());
+	assert_eq!(75.0, child_0_layout.height());
 
-	assert_eq!(75.0, child_1_layout.left);
-	assert_eq!(0.0, child_1_layout.top);
-	assert_eq!(125.0, child_1_layout.width);
-	assert_eq!(125.0, child_1_layout.height);
+	assert_eq!(75.0, child_1_layout.left());
+	assert_eq!(0.0, child_1_layout.top());
+	assert_eq!(125.0, child_1_layout.width());
+	assert_eq!(125.0, child_1_layout.height());
 }
 
 #[test]
@@ -863,20 +863,20 @@ fn test_aspect_ratio_width_as_flex_basis() {
 	let child_0_layout = root_child_0.get_layout();
 	let child_1_layout = root_child_1.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(200.0, root_layout.width);
-	assert_eq!(200.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(200.0, root_layout.width());
+	assert_eq!(200.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(75.0, child_0_layout.width);
-	assert_eq!(75.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(75.0, child_0_layout.width());
+	assert_eq!(75.0, child_0_layout.height());
 
-	assert_eq!(0.0, child_1_layout.left);
-	assert_eq!(75.0, child_1_layout.top);
-	assert_eq!(125.0, child_1_layout.width);
-	assert_eq!(125.0, child_1_layout.height);
+	assert_eq!(0.0, child_1_layout.left());
+	assert_eq!(75.0, child_1_layout.top());
+	assert_eq!(125.0, child_1_layout.width());
+	assert_eq!(125.0, child_1_layout.height());
 }
 
 #[test]
@@ -905,15 +905,15 @@ fn test_aspect_ratio_overrides_flex_grow_row() {
 	let root_layout = root.get_layout();
 	let child_0_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(100.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(100.0, child_0_layout.height());
 }
 
 #[test]
@@ -941,15 +941,15 @@ fn test_aspect_ratio_overrides_flex_grow_column() {
 	let root_layout = root.get_layout();
 	let child_0_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(100.0, child_0_layout.width);
-	assert_eq!(50.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(100.0, child_0_layout.width());
+	assert_eq!(50.0, child_0_layout.height());
 }
 
 #[test]
@@ -978,15 +978,15 @@ fn test_aspect_ratio_left_right_absolute() {
 	let root_layout = root.get_layout();
 	let child_0_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(10.0, child_0_layout.left);
-	assert_eq!(10.0, child_0_layout.top);
-	assert_eq!(80.0, child_0_layout.width);
-	assert_eq!(80.0, child_0_layout.height);
+	assert_eq!(10.0, child_0_layout.left());
+	assert_eq!(10.0, child_0_layout.top());
+	assert_eq!(80.0, child_0_layout.width());
+	assert_eq!(80.0, child_0_layout.height());
 }
 
 #[test]
@@ -1015,15 +1015,15 @@ fn test_aspect_ratio_top_bottom_absolute() {
 	let root_layout = root.get_layout();
 	let child_0_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(10.0, child_0_layout.left);
-	assert_eq!(10.0, child_0_layout.top);
-	assert_eq!(80.0, child_0_layout.width);
-	assert_eq!(80.0, child_0_layout.height);
+	assert_eq!(10.0, child_0_layout.left());
+	assert_eq!(10.0, child_0_layout.top());
+	assert_eq!(80.0, child_0_layout.width());
+	assert_eq!(80.0, child_0_layout.height());
 }
 
 #[test]
@@ -1050,15 +1050,15 @@ fn test_aspect_ratio_width_overrides_align_stretch_row() {
 	let root_layout = root.get_layout();
 	let child_0_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(50.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(50.0, child_0_layout.height());
 }
 
 #[test]
@@ -1084,15 +1084,15 @@ fn test_aspect_ratio_height_overrides_align_stretch_column() {
 	let root_layout = root.get_layout();
 	let child_0_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(50.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(50.0, child_0_layout.height());
 }
 
 #[test]
@@ -1118,15 +1118,15 @@ fn test_aspect_ratio_allow_child_overflow_parent_size() {
 	let root_layout = root.get_layout();
 	let child_0_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(50.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(50.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(200.0, child_0_layout.width);
-	assert_eq!(50.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(200.0, child_0_layout.width());
+	assert_eq!(50.0, child_0_layout.height());
 }
 
 #[test]
@@ -1156,15 +1156,15 @@ fn test_aspect_ratio_defined_main_with_margin() {
 	let root_layout = root.get_layout();
 	let child_0_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(25.0, child_0_layout.left);
-	assert_eq!(25.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(50.0, child_0_layout.height);
+	assert_eq!(25.0, child_0_layout.left());
+	assert_eq!(25.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(50.0, child_0_layout.height());
 }
 
 #[test]
@@ -1194,13 +1194,13 @@ fn test_aspect_ratio_defined_cross_with_margin() {
 	let root_layout = root.get_layout();
 	let child_0_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(25.0, child_0_layout.left);
-	assert_eq!(25.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(50.0, child_0_layout.height);
+	assert_eq!(25.0, child_0_layout.left());
+	assert_eq!(25.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(50.0, child_0_layout.height());
 }

--- a/tests/baseline_func_test.rs
+++ b/tests/baseline_func_test.rs
@@ -53,23 +53,23 @@ fn test_align_baseline_customer_func() {
 	let child_1_layout = root_child_1.get_layout();
 	let child_1_child_0_layout = root_child_1_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(50.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(50.0, child_0_layout.height());
 
-	assert_eq!(50.0, child_1_layout.left);
-	assert_eq!(40.0, child_1_layout.top);
-	assert_eq!(50.0, child_1_layout.width);
-	assert_eq!(20.0, child_1_layout.height);
+	assert_eq!(50.0, child_1_layout.left());
+	assert_eq!(40.0, child_1_layout.top());
+	assert_eq!(50.0, child_1_layout.width());
+	assert_eq!(20.0, child_1_layout.height());
 
-	assert_eq!(0.0, child_1_child_0_layout.left);
-	assert_eq!(0.0, child_1_child_0_layout.top);
-	assert_eq!(50.0, child_1_child_0_layout.width);
-	assert_eq!(20.0, child_1_child_0_layout.height);
+	assert_eq!(0.0, child_1_child_0_layout.left());
+	assert_eq!(0.0, child_1_child_0_layout.top());
+	assert_eq!(50.0, child_1_child_0_layout.width());
+	assert_eq!(20.0, child_1_child_0_layout.height());
 }

--- a/tests/border_test.rs
+++ b/tests/border_test.rs
@@ -21,19 +21,19 @@ fn test_border_no_size() {
 
 	let root_layout = root.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(20.0, root_layout.width);
-	assert_eq!(20.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(20.0, root_layout.width());
+	assert_eq!(20.0, root_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
 	let root_layout = root.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(20.0, root_layout.width);
-	assert_eq!(20.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(20.0, root_layout.width());
+	assert_eq!(20.0, root_layout.height());
 }
 
 #[test]
@@ -62,30 +62,30 @@ fn test_border_container_match_child() {
 	let root_layout = root.get_layout();
 	let child_0_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(30.0, root_layout.width);
-	assert_eq!(30.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(30.0, root_layout.width());
+	assert_eq!(30.0, root_layout.height());
 
-	assert_eq!(10.0, child_0_layout.left);
-	assert_eq!(10.0, child_0_layout.top);
-	assert_eq!(10.0, child_0_layout.width);
-	assert_eq!(10.0, child_0_layout.height);
+	assert_eq!(10.0, child_0_layout.left());
+	assert_eq!(10.0, child_0_layout.top());
+	assert_eq!(10.0, child_0_layout.width());
+	assert_eq!(10.0, child_0_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
 	let root_layout = root.get_layout();
 	let child_0_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(30.0, root_layout.width);
-	assert_eq!(30.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(30.0, root_layout.width());
+	assert_eq!(30.0, root_layout.height());
 
-	assert_eq!(10.0, child_0_layout.left);
-	assert_eq!(10.0, child_0_layout.top);
-	assert_eq!(10.0, child_0_layout.width);
-	assert_eq!(10.0, child_0_layout.height);
+	assert_eq!(10.0, child_0_layout.left());
+	assert_eq!(10.0, child_0_layout.top());
+	assert_eq!(10.0, child_0_layout.width());
+	assert_eq!(10.0, child_0_layout.height());
 }
 
 #[test]
@@ -115,30 +115,30 @@ fn test_border_flex_child() {
 	let root_layout = root.get_layout();
 	let child_0_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(10.0, child_0_layout.left);
-	assert_eq!(10.0, child_0_layout.top);
-	assert_eq!(10.0, child_0_layout.width);
-	assert_eq!(80.0, child_0_layout.height);
+	assert_eq!(10.0, child_0_layout.left());
+	assert_eq!(10.0, child_0_layout.top());
+	assert_eq!(10.0, child_0_layout.width());
+	assert_eq!(80.0, child_0_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
 	let root_layout = root.get_layout();
 	let child_0_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(80.0, child_0_layout.left);
-	assert_eq!(10.0, child_0_layout.top);
-	assert_eq!(10.0, child_0_layout.width);
-	assert_eq!(80.0, child_0_layout.height);
+	assert_eq!(80.0, child_0_layout.left());
+	assert_eq!(10.0, child_0_layout.top());
+	assert_eq!(10.0, child_0_layout.width());
+	assert_eq!(80.0, child_0_layout.height());
 }
 
 #[test]
@@ -167,30 +167,30 @@ fn test_border_stretch_child() {
 	let root_layout = root.get_layout();
 	let child_0_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(10.0, child_0_layout.left);
-	assert_eq!(10.0, child_0_layout.top);
-	assert_eq!(80.0, child_0_layout.width);
-	assert_eq!(10.0, child_0_layout.height);
+	assert_eq!(10.0, child_0_layout.left());
+	assert_eq!(10.0, child_0_layout.top());
+	assert_eq!(80.0, child_0_layout.width());
+	assert_eq!(10.0, child_0_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
 	let root_layout = root.get_layout();
 	let child_0_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(10.0, child_0_layout.left);
-	assert_eq!(10.0, child_0_layout.top);
-	assert_eq!(80.0, child_0_layout.width);
-	assert_eq!(10.0, child_0_layout.height);
+	assert_eq!(10.0, child_0_layout.left());
+	assert_eq!(10.0, child_0_layout.top());
+	assert_eq!(80.0, child_0_layout.width());
+	assert_eq!(10.0, child_0_layout.height());
 }
 
 #[test]
@@ -221,28 +221,28 @@ fn test_border_center_child() {
 	let root_layout = root.get_layout();
 	let child_0_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(40.0, child_0_layout.left);
-	assert_eq!(35.0, child_0_layout.top);
-	assert_eq!(10.0, child_0_layout.width);
-	assert_eq!(10.0, child_0_layout.height);
+	assert_eq!(40.0, child_0_layout.left());
+	assert_eq!(35.0, child_0_layout.top());
+	assert_eq!(10.0, child_0_layout.width());
+	assert_eq!(10.0, child_0_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
 	let root_layout = root.get_layout();
 	let child_0_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(50.0, child_0_layout.left);
-	assert_eq!(35.0, child_0_layout.top);
-	assert_eq!(10.0, child_0_layout.width);
-	assert_eq!(10.0, child_0_layout.height);
+	assert_eq!(50.0, child_0_layout.left());
+	assert_eq!(35.0, child_0_layout.top());
+	assert_eq!(10.0, child_0_layout.width());
+	assert_eq!(10.0, child_0_layout.height());
 }

--- a/tests/context_test.rs
+++ b/tests/context_test.rs
@@ -49,10 +49,10 @@ fn test_context_2_safe_check() {
 
 	let root_layout = root.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(1.0, root_layout.width);
-	assert_eq!(1.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(1.0, root_layout.width());
+	assert_eq!(1.0, root_layout.height());
 }
 
 #[test]
@@ -83,10 +83,10 @@ fn test_context_2() {
 
 	let root_layout = root.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(4.0, root_layout.width);
-	assert_eq!(1.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(4.0, root_layout.width());
+	assert_eq!(1.0, root_layout.height());
 }
 
 #[test]
@@ -139,8 +139,8 @@ fn test_context_3() {
 
 	let root_layout = root.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(22.0, root_layout.width);
-	assert_eq!(10.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(22.0, root_layout.width());
+	assert_eq!(10.0, root_layout.height());
 }

--- a/tests/context_test.rs
+++ b/tests/context_test.rs
@@ -1,0 +1,97 @@
+extern crate yoga;
+
+use yoga::{ContextNode, Direction, MeasureMode, NodeRef, Size, Undefined};
+
+#[test]
+fn test_context_1() {
+	let mut root = ContextNode::new();
+	let ref mut context = "test".to_string();
+	root.set_context(context);
+
+	let retrieved_context = root.get_own_context();
+
+	assert_eq!(context, retrieved_context);
+}
+
+#[test]
+fn test_context_2() {
+	extern "C" fn measure(
+		node_ref: NodeRef,
+		_: f32,
+		_: MeasureMode,
+		_: f32,
+		_: MeasureMode,
+	) -> Size {
+		let context: &String = ContextNode::get_context(&node_ref);
+
+		Size {
+			width: context.len() as f32,
+			height: if context == "test" { 1.0 } else { 0.0 },
+		}
+	}
+
+	let mut root = ContextNode::new();
+	let ref mut context = "test".to_string();
+	root.set_context(context);
+	root.set_measure_func(Some(measure));
+
+	root.calculate_layout(Undefined, Undefined, Direction::LTR);
+
+	let root_layout = root.get_layout();
+
+	assert_eq!(0.0, root_layout.left);
+	assert_eq!(0.0, root_layout.top);
+	assert_eq!(4.0, root_layout.width);
+	assert_eq!(1.0, root_layout.height);
+}
+
+#[test]
+fn test_context_3() {
+	struct SimpleFont {
+		letter_width: f32,
+		letter_height: f32,
+	}
+
+	struct CustomData<'a> {
+		text: String,
+		font: &'a SimpleFont,
+	}
+
+	extern "C" fn measure(
+		node_ref: NodeRef,
+		_: f32,
+		_: MeasureMode,
+		_: f32,
+		_: MeasureMode,
+	) -> Size {
+		let context: &CustomData = ContextNode::get_context(&node_ref);
+
+		Size {
+			width: context.text.len() as f32 * context.font.letter_width,
+			height: context.font.letter_height,
+		}
+	}
+
+	let shared_font = SimpleFont {
+		letter_width: 2.0,
+		letter_height: 10.0,
+	};
+
+	let mut data = CustomData {
+		text: "hello world".to_string(),
+		font: &shared_font,
+	};
+
+	let mut root = ContextNode::new();
+	root.set_context(&mut data);
+	root.set_measure_func(Some(measure));
+
+	root.calculate_layout(Undefined, Undefined, Direction::LTR);
+
+	let root_layout = root.get_layout();
+
+	assert_eq!(0.0, root_layout.left);
+	assert_eq!(0.0, root_layout.top);
+	assert_eq!(22.0, root_layout.width);
+	assert_eq!(10.0, root_layout.height);
+}

--- a/tests/context_test.rs
+++ b/tests/context_test.rs
@@ -7,7 +7,7 @@ use yoga::{Context, Direction, MeasureMode, Node, NodeRef, Size, Undefined};
 #[test]
 fn test_context_1() {
 	let mut root = Node::new();
-	let ref mut context = Context(Box::new("test".to_string()));
+	let ref mut context = Context::new("test".to_string());
 	root.set_context(context);
 
 	let retrieved_context = root.get_own_context();
@@ -41,7 +41,7 @@ fn test_context_2_safe_check() {
 	}
 
 	let mut root = Node::new();
-	let ref mut context = Context(Box::new("test".to_string()));
+	let ref mut context = Context::new("test".to_string());
 	root.set_context(context);
 	root.set_measure_func(Some(measure));
 
@@ -75,7 +75,7 @@ fn test_context_2() {
 	}
 
 	let mut root = Node::new();
-	let ref mut context = Context(Box::new("test".to_string()));
+	let ref mut context = Context::new("test".to_string());
 	root.set_context(context);
 	root.set_measure_func(Some(measure));
 
@@ -126,10 +126,10 @@ fn test_context_3() {
 		letter_height: 10.0,
 	}));
 
-	let mut data = Context(Box::new(CustomData {
+	let mut data = Context::new(CustomData {
 		text: "hello world".to_string(),
 		font: shared_font,
-	}));
+	});
 
 	let mut root = Node::new();
 	root.set_context(&mut data);

--- a/tests/dimension_test.rs
+++ b/tests/dimension_test.rs
@@ -21,30 +21,30 @@ fn test_wrap_child() {
 	let root_layout = root.get_layout();
 	let child_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_layout.left);
-	assert_eq!(0.0, child_layout.top);
-	assert_eq!(100.0, child_layout.width);
-	assert_eq!(100.0, child_layout.height);
+	assert_eq!(0.0, child_layout.left());
+	assert_eq!(0.0, child_layout.top());
+	assert_eq!(100.0, child_layout.width());
+	assert_eq!(100.0, child_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
 	let root_layout = root.get_layout();
 	let child_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_layout.left);
-	assert_eq!(0.0, child_layout.top);
-	assert_eq!(100.0, child_layout.width);
-	assert_eq!(100.0, child_layout.height);
+	assert_eq!(0.0, child_layout.left());
+	assert_eq!(0.0, child_layout.top());
+	assert_eq!(100.0, child_layout.width());
+	assert_eq!(100.0, child_layout.height());
 }
 
 #[test]
@@ -68,20 +68,20 @@ fn test_wrap_grandchild() {
 	let child_0_layout = root_child_0.get_layout();
 	let child_0_child_0_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(100.0, child_0_layout.width);
-	assert_eq!(100.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(100.0, child_0_layout.width());
+	assert_eq!(100.0, child_0_layout.height());
 
-	assert_eq!(0.0, child_0_child_0_layout.left);
-	assert_eq!(0.0, child_0_child_0_layout.top);
-	assert_eq!(100.0, child_0_child_0_layout.width);
-	assert_eq!(100.0, child_0_child_0_layout.height);
+	assert_eq!(0.0, child_0_child_0_layout.left());
+	assert_eq!(0.0, child_0_child_0_layout.top());
+	assert_eq!(100.0, child_0_child_0_layout.width());
+	assert_eq!(100.0, child_0_child_0_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
@@ -89,18 +89,18 @@ fn test_wrap_grandchild() {
 	let child_0_layout = root_child_0.get_layout();
 	let child_0_child_0_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(100.0, child_0_layout.width);
-	assert_eq!(100.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(100.0, child_0_layout.width());
+	assert_eq!(100.0, child_0_layout.height());
 
-	assert_eq!(0.0, child_0_child_0_layout.left);
-	assert_eq!(0.0, child_0_child_0_layout.top);
-	assert_eq!(100.0, child_0_child_0_layout.width);
-	assert_eq!(100.0, child_0_child_0_layout.height);
+	assert_eq!(0.0, child_0_child_0_layout.left());
+	assert_eq!(0.0, child_0_child_0_layout.top());
+	assert_eq!(100.0, child_0_child_0_layout.width());
+	assert_eq!(100.0, child_0_child_0_layout.height());
 }

--- a/tests/dirty_marking.rs
+++ b/tests/dirty_marking.rs
@@ -119,8 +119,8 @@ fn test_dirty_mark_all_children_as_dirty_when_display_changes() {
 	root.calculate_layout(Undefined, Undefined, Direction::LTR);
 
 	let root_child_1_child_0_child_0_layout = root_child_1_child_0_child_0.get_layout();
-	assert_eq!(0.0, root_child_1_child_0_child_0_layout.width);
-	assert_eq!(0.0, root_child_1_child_0_child_0_layout.height);
+	assert_eq!(0.0, root_child_1_child_0_child_0_layout.width());
+	assert_eq!(0.0, root_child_1_child_0_child_0_layout.height());
 
 	root_child_0.set_display(Display::None);
 	root_child_1.set_display(Display::Flex);
@@ -128,8 +128,8 @@ fn test_dirty_mark_all_children_as_dirty_when_display_changes() {
 	root.calculate_layout(Undefined, Undefined, Direction::LTR);
 
 	let root_child_1_child_0_child_0_layout = root_child_1_child_0_child_0.get_layout();
-	assert_eq!(8.0, root_child_1_child_0_child_0_layout.width);
-	assert_eq!(16.0, root_child_1_child_0_child_0_layout.height);
+	assert_eq!(8.0, root_child_1_child_0_child_0_layout.width());
+	assert_eq!(16.0, root_child_1_child_0_child_0_layout.height());
 
 	root_child_0.set_display(Display::Flex);
 	root_child_1.set_display(Display::None);
@@ -137,8 +137,8 @@ fn test_dirty_mark_all_children_as_dirty_when_display_changes() {
 	root.calculate_layout(Undefined, Undefined, Direction::LTR);
 
 	let root_child_1_child_0_child_0_layout = root_child_1_child_0_child_0.get_layout();
-	assert_eq!(0.0, root_child_1_child_0_child_0_layout.width);
-	assert_eq!(0.0, root_child_1_child_0_child_0_layout.height);
+	assert_eq!(0.0, root_child_1_child_0_child_0_layout.width());
+	assert_eq!(0.0, root_child_1_child_0_child_0_layout.height());
 
 	root_child_0.set_display(Display::None);
 	root_child_1.set_display(Display::Flex);
@@ -146,8 +146,8 @@ fn test_dirty_mark_all_children_as_dirty_when_display_changes() {
 	root.calculate_layout(Undefined, Undefined, Direction::LTR);
 
 	let root_child_1_child_0_child_0_layout = root_child_1_child_0_child_0.get_layout();
-	assert_eq!(8.0, root_child_1_child_0_child_0_layout.width);
-	assert_eq!(16.0, root_child_1_child_0_child_0_layout.height);
+	assert_eq!(8.0, root_child_1_child_0_child_0_layout.width());
+	assert_eq!(16.0, root_child_1_child_0_child_0_layout.height());
 }
 
 #[test]

--- a/tests/display_test.rs
+++ b/tests/display_test.rs
@@ -31,20 +31,20 @@ fn test_display_none() {
 	let child_0_layout = root_child_0.get_layout();
 	let child_1_layout = root_child_1.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(100.0, child_0_layout.width);
-	assert_eq!(100.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(100.0, child_0_layout.width());
+	assert_eq!(100.0, child_0_layout.height());
 
-	assert_eq!(0.0, child_1_layout.left);
-	assert_eq!(0.0, child_1_layout.top);
-	assert_eq!(0.0, child_1_layout.width);
-	assert_eq!(0.0, child_1_layout.height);
+	assert_eq!(0.0, child_1_layout.left());
+	assert_eq!(0.0, child_1_layout.top());
+	assert_eq!(0.0, child_1_layout.width());
+	assert_eq!(0.0, child_1_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
@@ -52,20 +52,20 @@ fn test_display_none() {
 	let child_0_layout = root_child_0.get_layout();
 	let child_1_layout = root_child_1.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(100.0, child_0_layout.width);
-	assert_eq!(100.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(100.0, child_0_layout.width());
+	assert_eq!(100.0, child_0_layout.height());
 
-	assert_eq!(0.0, child_1_layout.left);
-	assert_eq!(0.0, child_1_layout.top);
-	assert_eq!(0.0, child_1_layout.width);
-	assert_eq!(0.0, child_1_layout.height);
+	assert_eq!(0.0, child_1_layout.left());
+	assert_eq!(0.0, child_1_layout.top());
+	assert_eq!(0.0, child_1_layout.width());
+	assert_eq!(0.0, child_1_layout.height());
 }
 
 #[test]
@@ -98,20 +98,20 @@ fn test_display_none_fixed_size() {
 	let child_0_layout = root_child_0.get_layout();
 	let child_1_layout = root_child_1.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(100.0, child_0_layout.width);
-	assert_eq!(100.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(100.0, child_0_layout.width());
+	assert_eq!(100.0, child_0_layout.height());
 
-	assert_eq!(0.0, child_1_layout.left);
-	assert_eq!(0.0, child_1_layout.top);
-	assert_eq!(0.0, child_1_layout.width);
-	assert_eq!(0.0, child_1_layout.height);
+	assert_eq!(0.0, child_1_layout.left());
+	assert_eq!(0.0, child_1_layout.top());
+	assert_eq!(0.0, child_1_layout.width());
+	assert_eq!(0.0, child_1_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
@@ -119,20 +119,20 @@ fn test_display_none_fixed_size() {
 	let child_0_layout = root_child_0.get_layout();
 	let child_1_layout = root_child_1.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(100.0, child_0_layout.width);
-	assert_eq!(100.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(100.0, child_0_layout.width());
+	assert_eq!(100.0, child_0_layout.height());
 
-	assert_eq!(0.0, child_1_layout.left);
-	assert_eq!(0.0, child_1_layout.top);
-	assert_eq!(0.0, child_1_layout.width);
-	assert_eq!(0.0, child_1_layout.height);
+	assert_eq!(0.0, child_1_layout.left());
+	assert_eq!(0.0, child_1_layout.top());
+	assert_eq!(0.0, child_1_layout.width());
+	assert_eq!(0.0, child_1_layout.height());
 }
 
 #[test]
@@ -169,20 +169,20 @@ fn test_display_none_with_margin() {
 	let child_0_layout = root_child_0.get_layout();
 	let child_1_layout = root_child_1.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(0.0, child_0_layout.width);
-	assert_eq!(0.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(0.0, child_0_layout.width());
+	assert_eq!(0.0, child_0_layout.height());
 
-	assert_eq!(0.0, child_1_layout.left);
-	assert_eq!(0.0, child_1_layout.top);
-	assert_eq!(100.0, child_1_layout.width);
-	assert_eq!(100.0, child_1_layout.height);
+	assert_eq!(0.0, child_1_layout.left());
+	assert_eq!(0.0, child_1_layout.top());
+	assert_eq!(100.0, child_1_layout.width());
+	assert_eq!(100.0, child_1_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
@@ -190,20 +190,20 @@ fn test_display_none_with_margin() {
 	let child_0_layout = root_child_0.get_layout();
 	let child_1_layout = root_child_1.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(0.0, child_0_layout.width);
-	assert_eq!(0.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(0.0, child_0_layout.width());
+	assert_eq!(0.0, child_0_layout.height());
 
-	assert_eq!(0.0, child_1_layout.left);
-	assert_eq!(0.0, child_1_layout.top);
-	assert_eq!(100.0, child_1_layout.width);
-	assert_eq!(100.0, child_1_layout.height);
+	assert_eq!(0.0, child_1_layout.left());
+	assert_eq!(0.0, child_1_layout.top());
+	assert_eq!(100.0, child_1_layout.width());
+	assert_eq!(100.0, child_1_layout.height());
 }
 
 #[test]
@@ -264,30 +264,30 @@ fn test_display_none_with_child() {
 	let child_1_child_0_layout = root_child_1_child_0.get_layout();
 	let child_2_layout = root_child_2.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(100.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(100.0, child_0_layout.height());
 
-	assert_eq!(0.0, child_1_layout.left);
-	assert_eq!(0.0, child_1_layout.top);
-	assert_eq!(0.0, child_1_layout.width);
-	assert_eq!(0.0, child_1_layout.height);
+	assert_eq!(0.0, child_1_layout.left());
+	assert_eq!(0.0, child_1_layout.top());
+	assert_eq!(0.0, child_1_layout.width());
+	assert_eq!(0.0, child_1_layout.height());
 
-	assert_eq!(0.0, child_1_child_0_layout.left);
-	assert_eq!(0.0, child_1_child_0_layout.top);
-	assert_eq!(0.0, child_1_child_0_layout.width);
-	assert_eq!(0.0, child_1_child_0_layout.height);
+	assert_eq!(0.0, child_1_child_0_layout.left());
+	assert_eq!(0.0, child_1_child_0_layout.top());
+	assert_eq!(0.0, child_1_child_0_layout.width());
+	assert_eq!(0.0, child_1_child_0_layout.height());
 
-	assert_eq!(50.0, child_2_layout.left);
-	assert_eq!(0.0, child_2_layout.top);
-	assert_eq!(50.0, child_2_layout.width);
-	assert_eq!(100.0, child_2_layout.height);
+	assert_eq!(50.0, child_2_layout.left());
+	assert_eq!(0.0, child_2_layout.top());
+	assert_eq!(50.0, child_2_layout.width());
+	assert_eq!(100.0, child_2_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
@@ -297,30 +297,30 @@ fn test_display_none_with_child() {
 	let child_1_child_0_layout = root_child_1_child_0.get_layout();
 	let child_2_layout = root_child_2.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(50.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(100.0, child_0_layout.height);
+	assert_eq!(50.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(100.0, child_0_layout.height());
 
-	assert_eq!(0.0, child_1_layout.left);
-	assert_eq!(0.0, child_1_layout.top);
-	assert_eq!(0.0, child_1_layout.width);
-	assert_eq!(0.0, child_1_layout.height);
+	assert_eq!(0.0, child_1_layout.left());
+	assert_eq!(0.0, child_1_layout.top());
+	assert_eq!(0.0, child_1_layout.width());
+	assert_eq!(0.0, child_1_layout.height());
 
-	assert_eq!(0.0, child_1_child_0_layout.left);
-	assert_eq!(0.0, child_1_child_0_layout.top);
-	assert_eq!(0.0, child_1_child_0_layout.width);
-	assert_eq!(0.0, child_1_child_0_layout.height);
+	assert_eq!(0.0, child_1_child_0_layout.left());
+	assert_eq!(0.0, child_1_child_0_layout.top());
+	assert_eq!(0.0, child_1_child_0_layout.width());
+	assert_eq!(0.0, child_1_child_0_layout.height());
 
-	assert_eq!(0.0, child_2_layout.left);
-	assert_eq!(0.0, child_2_layout.top);
-	assert_eq!(50.0, child_2_layout.width);
-	assert_eq!(100.0, child_2_layout.height);
+	assert_eq!(0.0, child_2_layout.left());
+	assert_eq!(0.0, child_2_layout.top());
+	assert_eq!(50.0, child_2_layout.width());
+	assert_eq!(100.0, child_2_layout.height());
 }
 
 #[test]
@@ -353,20 +353,20 @@ fn test_display_none_with_position() {
 	let child_0_layout = root_child_0.get_layout();
 	let child_1_layout = root_child_1.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(100.0, child_0_layout.width);
-	assert_eq!(100.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(100.0, child_0_layout.width());
+	assert_eq!(100.0, child_0_layout.height());
 
-	assert_eq!(0.0, child_1_layout.left);
-	assert_eq!(0.0, child_1_layout.top);
-	assert_eq!(0.0, child_1_layout.width);
-	assert_eq!(0.0, child_1_layout.height);
+	assert_eq!(0.0, child_1_layout.left());
+	assert_eq!(0.0, child_1_layout.top());
+	assert_eq!(0.0, child_1_layout.width());
+	assert_eq!(0.0, child_1_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
@@ -374,18 +374,18 @@ fn test_display_none_with_position() {
 	let child_0_layout = root_child_0.get_layout();
 	let child_1_layout = root_child_1.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(100.0, child_0_layout.width);
-	assert_eq!(100.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(100.0, child_0_layout.width());
+	assert_eq!(100.0, child_0_layout.height());
 
-	assert_eq!(0.0, child_1_layout.left);
-	assert_eq!(0.0, child_1_layout.top);
-	assert_eq!(0.0, child_1_layout.width);
-	assert_eq!(0.0, child_1_layout.height);
+	assert_eq!(0.0, child_1_layout.left());
+	assert_eq!(0.0, child_1_layout.top());
+	assert_eq!(0.0, child_1_layout.width());
+	assert_eq!(0.0, child_1_layout.height());
 }

--- a/tests/edge_test.rs
+++ b/tests/edge_test.rs
@@ -30,32 +30,32 @@ fn test_start_overrides() {
 	let root_layout = root.get_layout();
 	let child_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(10.0, child_layout.left);
-	assert_eq!(20.0, child_layout.right);
-	assert_eq!(0.0, child_layout.top);
-	assert_eq!(70.0, child_layout.width);
-	assert_eq!(100.0, child_layout.height);
+	assert_eq!(10.0, child_layout.left());
+	assert_eq!(20.0, child_layout.right());
+	assert_eq!(0.0, child_layout.top());
+	assert_eq!(70.0, child_layout.width());
+	assert_eq!(100.0, child_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
 	let root_layout = root.get_layout();
 	let child_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(20.0, child_layout.left);
-	assert_eq!(10.0, child_layout.right);
-	assert_eq!(0.0, child_layout.top);
-	assert_eq!(70.0, child_layout.width);
-	assert_eq!(100.0, child_layout.height);
+	assert_eq!(20.0, child_layout.left());
+	assert_eq!(10.0, child_layout.right());
+	assert_eq!(0.0, child_layout.top());
+	assert_eq!(70.0, child_layout.width());
+	assert_eq!(100.0, child_layout.height());
 }
 
 #[test]
@@ -83,32 +83,32 @@ fn test_end_overrides() {
 	let root_layout = root.get_layout();
 	let child_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(20.0, child_layout.left);
-	assert_eq!(10.0, child_layout.right);
-	assert_eq!(0.0, child_layout.top);
-	assert_eq!(70.0, child_layout.width);
-	assert_eq!(100.0, child_layout.height);
+	assert_eq!(20.0, child_layout.left());
+	assert_eq!(10.0, child_layout.right());
+	assert_eq!(0.0, child_layout.top());
+	assert_eq!(70.0, child_layout.width());
+	assert_eq!(100.0, child_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
 	let root_layout = root.get_layout();
 	let child_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(10.0, child_layout.left);
-	assert_eq!(20.0, child_layout.right);
-	assert_eq!(0.0, child_layout.top);
-	assert_eq!(70.0, child_layout.width);
-	assert_eq!(100.0, child_layout.height);
+	assert_eq!(10.0, child_layout.left());
+	assert_eq!(20.0, child_layout.right());
+	assert_eq!(0.0, child_layout.top());
+	assert_eq!(70.0, child_layout.width());
+	assert_eq!(100.0, child_layout.height());
 }
 
 #[test]
@@ -135,32 +135,32 @@ fn test_horizontal_overridden() {
 	let root_layout = root.get_layout();
 	let child_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(20.0, child_layout.left);
-	assert_eq!(10.0, child_layout.right);
-	assert_eq!(0.0, child_layout.top);
-	assert_eq!(70.0, child_layout.width);
-	assert_eq!(100.0, child_layout.height);
+	assert_eq!(20.0, child_layout.left());
+	assert_eq!(10.0, child_layout.right());
+	assert_eq!(0.0, child_layout.top());
+	assert_eq!(70.0, child_layout.width());
+	assert_eq!(100.0, child_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
 	let root_layout = root.get_layout();
 	let child_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(20.0, child_layout.left);
-	assert_eq!(10.0, child_layout.right);
-	assert_eq!(0.0, child_layout.top);
-	assert_eq!(70.0, child_layout.width);
-	assert_eq!(100.0, child_layout.height);
+	assert_eq!(20.0, child_layout.left());
+	assert_eq!(10.0, child_layout.right());
+	assert_eq!(0.0, child_layout.top());
+	assert_eq!(70.0, child_layout.width());
+	assert_eq!(100.0, child_layout.height());
 }
 
 #[test]
@@ -187,34 +187,34 @@ fn test_vertical_overridden() {
 	let root_layout = root.get_layout();
 	let child_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_layout.left);
-	assert_eq!(0.0, child_layout.right);
-	assert_eq!(20.0, child_layout.top);
-	assert_eq!(10.0, child_layout.bottom);
-	assert_eq!(100.0, child_layout.width);
-	assert_eq!(70.0, child_layout.height);
+	assert_eq!(0.0, child_layout.left());
+	assert_eq!(0.0, child_layout.right());
+	assert_eq!(20.0, child_layout.top());
+	assert_eq!(10.0, child_layout.bottom());
+	assert_eq!(100.0, child_layout.width());
+	assert_eq!(70.0, child_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
 	let root_layout = root.get_layout();
 	let child_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_layout.left);
-	assert_eq!(0.0, child_layout.right);
-	assert_eq!(20.0, child_layout.top);
-	assert_eq!(10.0, child_layout.bottom);
-	assert_eq!(100.0, child_layout.width);
-	assert_eq!(70.0, child_layout.height);
+	assert_eq!(0.0, child_layout.left());
+	assert_eq!(0.0, child_layout.right());
+	assert_eq!(20.0, child_layout.top());
+	assert_eq!(10.0, child_layout.bottom());
+	assert_eq!(100.0, child_layout.width());
+	assert_eq!(70.0, child_layout.height());
 }
 
 #[test]
@@ -241,34 +241,34 @@ fn test_horizontal_overrides_all() {
 	let root_layout = root.get_layout();
 	let child_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(10.0, child_layout.left);
-	assert_eq!(10.0, child_layout.right);
-	assert_eq!(20.0, child_layout.top);
-	assert_eq!(20.0, child_layout.bottom);
-	assert_eq!(80.0, child_layout.width);
-	assert_eq!(60.0, child_layout.height);
+	assert_eq!(10.0, child_layout.left());
+	assert_eq!(10.0, child_layout.right());
+	assert_eq!(20.0, child_layout.top());
+	assert_eq!(20.0, child_layout.bottom());
+	assert_eq!(80.0, child_layout.width());
+	assert_eq!(60.0, child_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
 	let root_layout = root.get_layout();
 	let child_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(10.0, child_layout.left);
-	assert_eq!(10.0, child_layout.right);
-	assert_eq!(20.0, child_layout.top);
-	assert_eq!(20.0, child_layout.bottom);
-	assert_eq!(80.0, child_layout.width);
-	assert_eq!(60.0, child_layout.height);
+	assert_eq!(10.0, child_layout.left());
+	assert_eq!(10.0, child_layout.right());
+	assert_eq!(20.0, child_layout.top());
+	assert_eq!(20.0, child_layout.bottom());
+	assert_eq!(80.0, child_layout.width());
+	assert_eq!(60.0, child_layout.height());
 }
 
 #[test]
@@ -295,34 +295,34 @@ fn test_vertical_overrides_all() {
 	let root_layout = root.get_layout();
 	let child_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(20.0, child_layout.left);
-	assert_eq!(20.0, child_layout.right);
-	assert_eq!(10.0, child_layout.top);
-	assert_eq!(10.0, child_layout.bottom);
-	assert_eq!(60.0, child_layout.width);
-	assert_eq!(80.0, child_layout.height);
+	assert_eq!(20.0, child_layout.left());
+	assert_eq!(20.0, child_layout.right());
+	assert_eq!(10.0, child_layout.top());
+	assert_eq!(10.0, child_layout.bottom());
+	assert_eq!(60.0, child_layout.width());
+	assert_eq!(80.0, child_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
 	let root_layout = root.get_layout();
 	let child_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(20.0, child_layout.left);
-	assert_eq!(20.0, child_layout.right);
-	assert_eq!(10.0, child_layout.top);
-	assert_eq!(10.0, child_layout.bottom);
-	assert_eq!(60.0, child_layout.width);
-	assert_eq!(80.0, child_layout.height);
+	assert_eq!(20.0, child_layout.left());
+	assert_eq!(20.0, child_layout.right());
+	assert_eq!(10.0, child_layout.top());
+	assert_eq!(10.0, child_layout.bottom());
+	assert_eq!(60.0, child_layout.width());
+	assert_eq!(80.0, child_layout.height());
 }
 
 #[test]
@@ -352,32 +352,32 @@ fn test_all_overridden() {
 	let root_layout = root.get_layout();
 	let child_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(10.0, child_layout.left);
-	assert_eq!(10.0, child_layout.right);
-	assert_eq!(10.0, child_layout.top);
-	assert_eq!(10.0, child_layout.bottom);
-	assert_eq!(80.0, child_layout.width);
-	assert_eq!(80.0, child_layout.height);
+	assert_eq!(10.0, child_layout.left());
+	assert_eq!(10.0, child_layout.right());
+	assert_eq!(10.0, child_layout.top());
+	assert_eq!(10.0, child_layout.bottom());
+	assert_eq!(80.0, child_layout.width());
+	assert_eq!(80.0, child_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
 	let root_layout = root.get_layout();
 	let child_layout = root_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(10.0, child_layout.left);
-	assert_eq!(10.0, child_layout.right);
-	assert_eq!(10.0, child_layout.top);
-	assert_eq!(10.0, child_layout.bottom);
-	assert_eq!(80.0, child_layout.width);
-	assert_eq!(80.0, child_layout.height);
+	assert_eq!(10.0, child_layout.left());
+	assert_eq!(10.0, child_layout.right());
+	assert_eq!(10.0, child_layout.top());
+	assert_eq!(10.0, child_layout.bottom());
+	assert_eq!(80.0, child_layout.width());
+	assert_eq!(80.0, child_layout.height());
 }

--- a/tests/flex_direction_test.rs
+++ b/tests/flex_direction_test.rs
@@ -40,25 +40,25 @@ fn test_flex_direction_column_no_height() {
 	let child_1_layout = root_child_1.get_layout();
 	let child_2_layout = root_child_2.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(30.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(30.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(100.0, child_0_layout.width);
-	assert_eq!(10.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(100.0, child_0_layout.width());
+	assert_eq!(10.0, child_0_layout.height());
 
-	assert_eq!(0.0, child_1_layout.left);
-	assert_eq!(10.0, child_1_layout.top);
-	assert_eq!(100.0, child_1_layout.width);
-	assert_eq!(10.0, child_1_layout.height);
+	assert_eq!(0.0, child_1_layout.left());
+	assert_eq!(10.0, child_1_layout.top());
+	assert_eq!(100.0, child_1_layout.width());
+	assert_eq!(10.0, child_1_layout.height());
 
-	assert_eq!(0.0, child_2_layout.left);
-	assert_eq!(20.0, child_2_layout.top);
-	assert_eq!(100.0, child_2_layout.width);
-	assert_eq!(10.0, child_2_layout.height);
+	assert_eq!(0.0, child_2_layout.left());
+	assert_eq!(20.0, child_2_layout.top());
+	assert_eq!(100.0, child_2_layout.width());
+	assert_eq!(10.0, child_2_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
@@ -67,25 +67,25 @@ fn test_flex_direction_column_no_height() {
 	let child_1_layout = root_child_1.get_layout();
 	let child_2_layout = root_child_2.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(30.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(30.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(100.0, child_0_layout.width);
-	assert_eq!(10.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(100.0, child_0_layout.width());
+	assert_eq!(10.0, child_0_layout.height());
 
-	assert_eq!(0.0, child_1_layout.left);
-	assert_eq!(10.0, child_1_layout.top);
-	assert_eq!(100.0, child_1_layout.width);
-	assert_eq!(10.0, child_1_layout.height);
+	assert_eq!(0.0, child_1_layout.left());
+	assert_eq!(10.0, child_1_layout.top());
+	assert_eq!(100.0, child_1_layout.width());
+	assert_eq!(10.0, child_1_layout.height());
 
-	assert_eq!(0.0, child_2_layout.left);
-	assert_eq!(20.0, child_2_layout.top);
-	assert_eq!(100.0, child_2_layout.width);
-	assert_eq!(10.0, child_2_layout.height);
+	assert_eq!(0.0, child_2_layout.left());
+	assert_eq!(20.0, child_2_layout.top());
+	assert_eq!(100.0, child_2_layout.width());
+	assert_eq!(10.0, child_2_layout.height());
 }
 
 #[test]
@@ -125,25 +125,25 @@ fn test_flex_direction_row_no_width() {
 	let child_1_layout = root_child_1.get_layout();
 	let child_2_layout = root_child_2.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(30.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(30.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(10.0, child_0_layout.width);
-	assert_eq!(100.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(10.0, child_0_layout.width());
+	assert_eq!(100.0, child_0_layout.height());
 
-	assert_eq!(10.0, child_1_layout.left);
-	assert_eq!(0.0, child_1_layout.top);
-	assert_eq!(10.0, child_1_layout.width);
-	assert_eq!(100.0, child_1_layout.height);
+	assert_eq!(10.0, child_1_layout.left());
+	assert_eq!(0.0, child_1_layout.top());
+	assert_eq!(10.0, child_1_layout.width());
+	assert_eq!(100.0, child_1_layout.height());
 
-	assert_eq!(20.0, child_2_layout.left);
-	assert_eq!(0.0, child_2_layout.top);
-	assert_eq!(10.0, child_2_layout.width);
-	assert_eq!(100.0, child_2_layout.height);
+	assert_eq!(20.0, child_2_layout.left());
+	assert_eq!(0.0, child_2_layout.top());
+	assert_eq!(10.0, child_2_layout.width());
+	assert_eq!(100.0, child_2_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
@@ -152,25 +152,25 @@ fn test_flex_direction_row_no_width() {
 	let child_1_layout = root_child_1.get_layout();
 	let child_2_layout = root_child_2.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(30.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(30.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(20.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(10.0, child_0_layout.width);
-	assert_eq!(100.0, child_0_layout.height);
+	assert_eq!(20.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(10.0, child_0_layout.width());
+	assert_eq!(100.0, child_0_layout.height());
 
-	assert_eq!(10.0, child_1_layout.left);
-	assert_eq!(0.0, child_1_layout.top);
-	assert_eq!(10.0, child_1_layout.width);
-	assert_eq!(100.0, child_1_layout.height);
+	assert_eq!(10.0, child_1_layout.left());
+	assert_eq!(0.0, child_1_layout.top());
+	assert_eq!(10.0, child_1_layout.width());
+	assert_eq!(100.0, child_1_layout.height());
 
-	assert_eq!(0.0, child_2_layout.left);
-	assert_eq!(0.0, child_2_layout.top);
-	assert_eq!(10.0, child_2_layout.width);
-	assert_eq!(100.0, child_2_layout.height);
+	assert_eq!(0.0, child_2_layout.left());
+	assert_eq!(0.0, child_2_layout.top());
+	assert_eq!(10.0, child_2_layout.width());
+	assert_eq!(100.0, child_2_layout.height());
 }
 
 #[test]
@@ -210,25 +210,25 @@ fn test_flex_direction_column() {
 	let child_1_layout = root_child_1.get_layout();
 	let child_2_layout = root_child_2.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(100.0, child_0_layout.width);
-	assert_eq!(10.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(100.0, child_0_layout.width());
+	assert_eq!(10.0, child_0_layout.height());
 
-	assert_eq!(0.0, child_1_layout.left);
-	assert_eq!(10.0, child_1_layout.top);
-	assert_eq!(100.0, child_1_layout.width);
-	assert_eq!(10.0, child_1_layout.height);
+	assert_eq!(0.0, child_1_layout.left());
+	assert_eq!(10.0, child_1_layout.top());
+	assert_eq!(100.0, child_1_layout.width());
+	assert_eq!(10.0, child_1_layout.height());
 
-	assert_eq!(0.0, child_2_layout.left);
-	assert_eq!(20.0, child_2_layout.top);
-	assert_eq!(100.0, child_2_layout.width);
-	assert_eq!(10.0, child_2_layout.height);
+	assert_eq!(0.0, child_2_layout.left());
+	assert_eq!(20.0, child_2_layout.top());
+	assert_eq!(100.0, child_2_layout.width());
+	assert_eq!(10.0, child_2_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
@@ -237,25 +237,25 @@ fn test_flex_direction_column() {
 	let child_1_layout = root_child_1.get_layout();
 	let child_2_layout = root_child_2.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(100.0, child_0_layout.width);
-	assert_eq!(10.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(100.0, child_0_layout.width());
+	assert_eq!(10.0, child_0_layout.height());
 
-	assert_eq!(0.0, child_1_layout.left);
-	assert_eq!(10.0, child_1_layout.top);
-	assert_eq!(100.0, child_1_layout.width);
-	assert_eq!(10.0, child_1_layout.height);
+	assert_eq!(0.0, child_1_layout.left());
+	assert_eq!(10.0, child_1_layout.top());
+	assert_eq!(100.0, child_1_layout.width());
+	assert_eq!(10.0, child_1_layout.height());
 
-	assert_eq!(0.0, child_2_layout.left);
-	assert_eq!(20.0, child_2_layout.top);
-	assert_eq!(100.0, child_2_layout.width);
-	assert_eq!(10.0, child_2_layout.height);
+	assert_eq!(0.0, child_2_layout.left());
+	assert_eq!(20.0, child_2_layout.top());
+	assert_eq!(100.0, child_2_layout.width());
+	assert_eq!(10.0, child_2_layout.height());
 }
 
 #[test]
@@ -296,25 +296,25 @@ fn test_flex_direction_row() {
 	let child_1_layout = root_child_1.get_layout();
 	let child_2_layout = root_child_2.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(10.0, child_0_layout.width);
-	assert_eq!(100.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(10.0, child_0_layout.width());
+	assert_eq!(100.0, child_0_layout.height());
 
-	assert_eq!(10.0, child_1_layout.left);
-	assert_eq!(0.0, child_1_layout.top);
-	assert_eq!(10.0, child_1_layout.width);
-	assert_eq!(100.0, child_1_layout.height);
+	assert_eq!(10.0, child_1_layout.left());
+	assert_eq!(0.0, child_1_layout.top());
+	assert_eq!(10.0, child_1_layout.width());
+	assert_eq!(100.0, child_1_layout.height());
 
-	assert_eq!(20.0, child_2_layout.left);
-	assert_eq!(0.0, child_2_layout.top);
-	assert_eq!(10.0, child_2_layout.width);
-	assert_eq!(100.0, child_2_layout.height);
+	assert_eq!(20.0, child_2_layout.left());
+	assert_eq!(0.0, child_2_layout.top());
+	assert_eq!(10.0, child_2_layout.width());
+	assert_eq!(100.0, child_2_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
@@ -323,25 +323,25 @@ fn test_flex_direction_row() {
 	let child_1_layout = root_child_1.get_layout();
 	let child_2_layout = root_child_2.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(90.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(10.0, child_0_layout.width);
-	assert_eq!(100.0, child_0_layout.height);
+	assert_eq!(90.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(10.0, child_0_layout.width());
+	assert_eq!(100.0, child_0_layout.height());
 
-	assert_eq!(80.0, child_1_layout.left);
-	assert_eq!(0.0, child_1_layout.top);
-	assert_eq!(10.0, child_1_layout.width);
-	assert_eq!(100.0, child_1_layout.height);
+	assert_eq!(80.0, child_1_layout.left());
+	assert_eq!(0.0, child_1_layout.top());
+	assert_eq!(10.0, child_1_layout.width());
+	assert_eq!(100.0, child_1_layout.height());
 
-	assert_eq!(70.0, child_2_layout.left);
-	assert_eq!(0.0, child_2_layout.top);
-	assert_eq!(10.0, child_2_layout.width);
-	assert_eq!(100.0, child_2_layout.height);
+	assert_eq!(70.0, child_2_layout.left());
+	assert_eq!(0.0, child_2_layout.top());
+	assert_eq!(10.0, child_2_layout.width());
+	assert_eq!(100.0, child_2_layout.height());
 }
 
 #[test]
@@ -382,25 +382,25 @@ fn test_flex_direction_column_reverse() {
 	let child_1_layout = root_child_1.get_layout();
 	let child_2_layout = root_child_2.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(90.0, child_0_layout.top);
-	assert_eq!(100.0, child_0_layout.width);
-	assert_eq!(10.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(90.0, child_0_layout.top());
+	assert_eq!(100.0, child_0_layout.width());
+	assert_eq!(10.0, child_0_layout.height());
 
-	assert_eq!(0.0, child_1_layout.left);
-	assert_eq!(80.0, child_1_layout.top);
-	assert_eq!(100.0, child_1_layout.width);
-	assert_eq!(10.0, child_1_layout.height);
+	assert_eq!(0.0, child_1_layout.left());
+	assert_eq!(80.0, child_1_layout.top());
+	assert_eq!(100.0, child_1_layout.width());
+	assert_eq!(10.0, child_1_layout.height());
 
-	assert_eq!(0.0, child_2_layout.left);
-	assert_eq!(70.0, child_2_layout.top);
-	assert_eq!(100.0, child_2_layout.width);
-	assert_eq!(10.0, child_2_layout.height);
+	assert_eq!(0.0, child_2_layout.left());
+	assert_eq!(70.0, child_2_layout.top());
+	assert_eq!(100.0, child_2_layout.width());
+	assert_eq!(10.0, child_2_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
@@ -409,25 +409,25 @@ fn test_flex_direction_column_reverse() {
 	let child_1_layout = root_child_1.get_layout();
 	let child_2_layout = root_child_2.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(90.0, child_0_layout.top);
-	assert_eq!(100.0, child_0_layout.width);
-	assert_eq!(10.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(90.0, child_0_layout.top());
+	assert_eq!(100.0, child_0_layout.width());
+	assert_eq!(10.0, child_0_layout.height());
 
-	assert_eq!(0.0, child_1_layout.left);
-	assert_eq!(80.0, child_1_layout.top);
-	assert_eq!(100.0, child_1_layout.width);
-	assert_eq!(10.0, child_1_layout.height);
+	assert_eq!(0.0, child_1_layout.left());
+	assert_eq!(80.0, child_1_layout.top());
+	assert_eq!(100.0, child_1_layout.width());
+	assert_eq!(10.0, child_1_layout.height());
 
-	assert_eq!(0.0, child_2_layout.left);
-	assert_eq!(70.0, child_2_layout.top);
-	assert_eq!(100.0, child_2_layout.width);
-	assert_eq!(10.0, child_2_layout.height);
+	assert_eq!(0.0, child_2_layout.left());
+	assert_eq!(70.0, child_2_layout.top());
+	assert_eq!(100.0, child_2_layout.width());
+	assert_eq!(10.0, child_2_layout.height());
 }
 
 #[test]
@@ -468,25 +468,25 @@ fn test_flex_direction_row_reverse() {
 	let child_1_layout = root_child_1.get_layout();
 	let child_2_layout = root_child_2.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(90.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(10.0, child_0_layout.width);
-	assert_eq!(100.0, child_0_layout.height);
+	assert_eq!(90.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(10.0, child_0_layout.width());
+	assert_eq!(100.0, child_0_layout.height());
 
-	assert_eq!(80.0, child_1_layout.left);
-	assert_eq!(0.0, child_1_layout.top);
-	assert_eq!(10.0, child_1_layout.width);
-	assert_eq!(100.0, child_1_layout.height);
+	assert_eq!(80.0, child_1_layout.left());
+	assert_eq!(0.0, child_1_layout.top());
+	assert_eq!(10.0, child_1_layout.width());
+	assert_eq!(100.0, child_1_layout.height());
 
-	assert_eq!(70.0, child_2_layout.left);
-	assert_eq!(0.0, child_2_layout.top);
-	assert_eq!(10.0, child_2_layout.width);
-	assert_eq!(100.0, child_2_layout.height);
+	assert_eq!(70.0, child_2_layout.left());
+	assert_eq!(0.0, child_2_layout.top());
+	assert_eq!(10.0, child_2_layout.width());
+	assert_eq!(100.0, child_2_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
@@ -495,23 +495,23 @@ fn test_flex_direction_row_reverse() {
 	let child_1_layout = root_child_1.get_layout();
 	let child_2_layout = root_child_2.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(10.0, child_0_layout.width);
-	assert_eq!(100.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(10.0, child_0_layout.width());
+	assert_eq!(100.0, child_0_layout.height());
 
-	assert_eq!(10.0, child_1_layout.left);
-	assert_eq!(0.0, child_1_layout.top);
-	assert_eq!(10.0, child_1_layout.width);
-	assert_eq!(100.0, child_1_layout.height);
+	assert_eq!(10.0, child_1_layout.left());
+	assert_eq!(0.0, child_1_layout.top());
+	assert_eq!(10.0, child_1_layout.width());
+	assert_eq!(100.0, child_1_layout.height());
 
-	assert_eq!(20.0, child_2_layout.left);
-	assert_eq!(0.0, child_2_layout.top);
-	assert_eq!(10.0, child_2_layout.width);
-	assert_eq!(100.0, child_2_layout.height);
+	assert_eq!(20.0, child_2_layout.left());
+	assert_eq!(0.0, child_2_layout.top());
+	assert_eq!(10.0, child_2_layout.width());
+	assert_eq!(100.0, child_2_layout.height());
 }

--- a/tests/flex_test.rs
+++ b/tests/flex_test.rs
@@ -33,20 +33,20 @@ fn test_flex_basis_flex_grow_column() {
 	let child_0_layout = root_child_0.get_layout();
 	let child_1_layout = root_child_1.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(100.0, child_0_layout.width);
-	assert_eq!(75.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(100.0, child_0_layout.width());
+	assert_eq!(75.0, child_0_layout.height());
 
-	assert_eq!(0.0, child_1_layout.left);
-	assert_eq!(75.0, child_1_layout.top);
-	assert_eq!(100.0, child_1_layout.width);
-	assert_eq!(25.0, child_1_layout.height);
+	assert_eq!(0.0, child_1_layout.left());
+	assert_eq!(75.0, child_1_layout.top());
+	assert_eq!(100.0, child_1_layout.width());
+	assert_eq!(25.0, child_1_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
@@ -54,20 +54,20 @@ fn test_flex_basis_flex_grow_column() {
 	let child_0_layout = root_child_0.get_layout();
 	let child_1_layout = root_child_1.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(100.0, child_0_layout.width);
-	assert_eq!(75.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(100.0, child_0_layout.width());
+	assert_eq!(75.0, child_0_layout.height());
 
-	assert_eq!(0.0, child_1_layout.left);
-	assert_eq!(75.0, child_1_layout.top);
-	assert_eq!(100.0, child_1_layout.width);
-	assert_eq!(25.0, child_1_layout.height);
+	assert_eq!(0.0, child_1_layout.left());
+	assert_eq!(75.0, child_1_layout.top());
+	assert_eq!(100.0, child_1_layout.width());
+	assert_eq!(25.0, child_1_layout.height());
 }
 
 #[test]
@@ -99,20 +99,20 @@ fn test_flex_basis_flex_grow_row() {
 	let child_0_layout = root_child_0.get_layout();
 	let child_1_layout = root_child_1.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(75.0, child_0_layout.width);
-	assert_eq!(100.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(75.0, child_0_layout.width());
+	assert_eq!(100.0, child_0_layout.height());
 
-	assert_eq!(75.0, child_1_layout.left);
-	assert_eq!(0.0, child_1_layout.top);
-	assert_eq!(25.0, child_1_layout.width);
-	assert_eq!(100.0, child_1_layout.height);
+	assert_eq!(75.0, child_1_layout.left());
+	assert_eq!(0.0, child_1_layout.top());
+	assert_eq!(25.0, child_1_layout.width());
+	assert_eq!(100.0, child_1_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
@@ -120,20 +120,20 @@ fn test_flex_basis_flex_grow_row() {
 	let child_0_layout = root_child_0.get_layout();
 	let child_1_layout = root_child_1.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(25.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(75.0, child_0_layout.width);
-	assert_eq!(100.0, child_0_layout.height);
+	assert_eq!(25.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(75.0, child_0_layout.width());
+	assert_eq!(100.0, child_0_layout.height());
 
-	assert_eq!(0.0, child_1_layout.left);
-	assert_eq!(0.0, child_1_layout.top);
-	assert_eq!(25.0, child_1_layout.width);
-	assert_eq!(100.0, child_1_layout.height);
+	assert_eq!(0.0, child_1_layout.left());
+	assert_eq!(0.0, child_1_layout.top());
+	assert_eq!(25.0, child_1_layout.width());
+	assert_eq!(100.0, child_1_layout.height());
 }
 
 #[test]
@@ -166,20 +166,20 @@ fn test_flex_basis_flex_shrink_column() {
 	let child_0_layout = root_child_0.get_layout();
 	let child_1_layout = root_child_1.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(100.0, child_0_layout.width);
-	assert_eq!(50.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(100.0, child_0_layout.width());
+	assert_eq!(50.0, child_0_layout.height());
 
-	assert_eq!(0.0, child_1_layout.left);
-	assert_eq!(50.0, child_1_layout.top);
-	assert_eq!(100.0, child_1_layout.width);
-	assert_eq!(50.0, child_1_layout.height);
+	assert_eq!(0.0, child_1_layout.left());
+	assert_eq!(50.0, child_1_layout.top());
+	assert_eq!(100.0, child_1_layout.width());
+	assert_eq!(50.0, child_1_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
@@ -187,20 +187,20 @@ fn test_flex_basis_flex_shrink_column() {
 	let child_0_layout = root_child_0.get_layout();
 	let child_1_layout = root_child_1.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(100.0, child_0_layout.width);
-	assert_eq!(50.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(100.0, child_0_layout.width());
+	assert_eq!(50.0, child_0_layout.height());
 
-	assert_eq!(0.0, child_1_layout.left);
-	assert_eq!(50.0, child_1_layout.top);
-	assert_eq!(100.0, child_1_layout.width);
-	assert_eq!(50.0, child_1_layout.height);
+	assert_eq!(0.0, child_1_layout.left());
+	assert_eq!(50.0, child_1_layout.top());
+	assert_eq!(100.0, child_1_layout.width());
+	assert_eq!(50.0, child_1_layout.height());
 }
 
 #[test]
@@ -234,20 +234,20 @@ fn test_flex_basis_flex_shrink_row() {
 	let child_0_layout = root_child_0.get_layout();
 	let child_1_layout = root_child_1.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(100.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(100.0, child_0_layout.height());
 
-	assert_eq!(50.0, child_1_layout.left);
-	assert_eq!(0.0, child_1_layout.top);
-	assert_eq!(50.0, child_1_layout.width);
-	assert_eq!(100.0, child_1_layout.height);
+	assert_eq!(50.0, child_1_layout.left());
+	assert_eq!(0.0, child_1_layout.top());
+	assert_eq!(50.0, child_1_layout.width());
+	assert_eq!(100.0, child_1_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
@@ -255,20 +255,20 @@ fn test_flex_basis_flex_shrink_row() {
 	let child_0_layout = root_child_0.get_layout();
 	let child_1_layout = root_child_1.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(50.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(100.0, child_0_layout.height);
+	assert_eq!(50.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(100.0, child_0_layout.height());
 
-	assert_eq!(0.0, child_1_layout.left);
-	assert_eq!(0.0, child_1_layout.top);
-	assert_eq!(50.0, child_1_layout.width);
-	assert_eq!(100.0, child_1_layout.height);
+	assert_eq!(0.0, child_1_layout.left());
+	assert_eq!(0.0, child_1_layout.top());
+	assert_eq!(50.0, child_1_layout.width());
+	assert_eq!(100.0, child_1_layout.height());
 }
 
 #[test]
@@ -311,25 +311,25 @@ fn test_flex_shrink_to_zero() {
 	let child_1_layout = root_child_1.get_layout();
 	let child_2_layout = root_child_2.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(50.0, root_layout.width);
-	assert_eq!(75.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(50.0, root_layout.width());
+	assert_eq!(75.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(50.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(50.0, child_0_layout.height());
 
-	assert_eq!(0.0, child_1_layout.left);
-	assert_eq!(50.0, child_1_layout.top);
-	assert_eq!(50.0, child_1_layout.width);
-	assert_eq!(0.0, child_1_layout.height);
+	assert_eq!(0.0, child_1_layout.left());
+	assert_eq!(50.0, child_1_layout.top());
+	assert_eq!(50.0, child_1_layout.width());
+	assert_eq!(0.0, child_1_layout.height());
 
-	assert_eq!(0.0, child_2_layout.left);
-	assert_eq!(50.0, child_2_layout.top);
-	assert_eq!(50.0, child_2_layout.width);
-	assert_eq!(50.0, child_2_layout.height);
+	assert_eq!(0.0, child_2_layout.left());
+	assert_eq!(50.0, child_2_layout.top());
+	assert_eq!(50.0, child_2_layout.width());
+	assert_eq!(50.0, child_2_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
@@ -338,25 +338,25 @@ fn test_flex_shrink_to_zero() {
 	let child_1_layout = root_child_1.get_layout();
 	let child_2_layout = root_child_2.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(50.0, root_layout.width);
-	assert_eq!(75.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(50.0, root_layout.width());
+	assert_eq!(75.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(50.0, child_0_layout.width);
-	assert_eq!(50.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(50.0, child_0_layout.width());
+	assert_eq!(50.0, child_0_layout.height());
 
-	assert_eq!(0.0, child_1_layout.left);
-	assert_eq!(50.0, child_1_layout.top);
-	assert_eq!(50.0, child_1_layout.width);
-	assert_eq!(0.0, child_1_layout.height);
+	assert_eq!(0.0, child_1_layout.left());
+	assert_eq!(50.0, child_1_layout.top());
+	assert_eq!(50.0, child_1_layout.width());
+	assert_eq!(0.0, child_1_layout.height());
 
-	assert_eq!(0.0, child_2_layout.left);
-	assert_eq!(50.0, child_2_layout.top);
-	assert_eq!(50.0, child_2_layout.width);
-	assert_eq!(50.0, child_2_layout.height);
+	assert_eq!(0.0, child_2_layout.left());
+	assert_eq!(50.0, child_2_layout.top());
+	assert_eq!(50.0, child_2_layout.width());
+	assert_eq!(50.0, child_2_layout.height());
 }
 
 #[test]
@@ -400,25 +400,25 @@ fn test_flex_basis_overrides_main_size() {
 	let child_1_layout = root_child_1.get_layout();
 	let child_2_layout = root_child_2.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(100.0, child_0_layout.width);
-	assert_eq!(60.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(100.0, child_0_layout.width());
+	assert_eq!(60.0, child_0_layout.height());
 
-	assert_eq!(0.0, child_1_layout.left);
-	assert_eq!(60.0, child_1_layout.top);
-	assert_eq!(100.0, child_1_layout.width);
-	assert_eq!(20.0, child_1_layout.height);
+	assert_eq!(0.0, child_1_layout.left());
+	assert_eq!(60.0, child_1_layout.top());
+	assert_eq!(100.0, child_1_layout.width());
+	assert_eq!(20.0, child_1_layout.height());
 
-	assert_eq!(0.0, child_2_layout.left);
-	assert_eq!(80.0, child_2_layout.top);
-	assert_eq!(100.0, child_2_layout.width);
-	assert_eq!(20.0, child_2_layout.height);
+	assert_eq!(0.0, child_2_layout.left());
+	assert_eq!(80.0, child_2_layout.top());
+	assert_eq!(100.0, child_2_layout.width());
+	assert_eq!(20.0, child_2_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
@@ -427,25 +427,25 @@ fn test_flex_basis_overrides_main_size() {
 	let child_1_layout = root_child_1.get_layout();
 	let child_2_layout = root_child_2.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(100.0, child_0_layout.width);
-	assert_eq!(60.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(100.0, child_0_layout.width());
+	assert_eq!(60.0, child_0_layout.height());
 
-	assert_eq!(0.0, child_1_layout.left);
-	assert_eq!(60.0, child_1_layout.top);
-	assert_eq!(100.0, child_1_layout.width);
-	assert_eq!(20.0, child_1_layout.height);
+	assert_eq!(0.0, child_1_layout.left());
+	assert_eq!(60.0, child_1_layout.top());
+	assert_eq!(100.0, child_1_layout.width());
+	assert_eq!(20.0, child_1_layout.height());
 
-	assert_eq!(0.0, child_2_layout.left);
-	assert_eq!(80.0, child_2_layout.top);
-	assert_eq!(100.0, child_2_layout.width);
-	assert_eq!(20.0, child_2_layout.height);
+	assert_eq!(0.0, child_2_layout.left());
+	assert_eq!(80.0, child_2_layout.top());
+	assert_eq!(100.0, child_2_layout.width());
+	assert_eq!(20.0, child_2_layout.height());
 }
 
 #[test]
@@ -474,20 +474,20 @@ fn test_flex_grow_shrink_at_most() {
 	let child_0_layout = root_child_0.get_layout();
 	let child_0_child_0_layout = root_child_0_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(100.0, child_0_layout.width);
-	assert_eq!(0.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(100.0, child_0_layout.width());
+	assert_eq!(0.0, child_0_layout.height());
 
-	assert_eq!(0.0, child_0_child_0_layout.left);
-	assert_eq!(0.0, child_0_child_0_layout.top);
-	assert_eq!(100.0, child_0_child_0_layout.width);
-	assert_eq!(0.0, child_0_child_0_layout.height);
+	assert_eq!(0.0, child_0_child_0_layout.left());
+	assert_eq!(0.0, child_0_child_0_layout.top());
+	assert_eq!(100.0, child_0_child_0_layout.width());
+	assert_eq!(0.0, child_0_child_0_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
@@ -495,18 +495,18 @@ fn test_flex_grow_shrink_at_most() {
 	let child_0_layout = root_child_0.get_layout();
 	let child_0_child_0_layout = root_child_0_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, child_0_layout.left);
-	assert_eq!(0.0, child_0_layout.top);
-	assert_eq!(100.0, child_0_layout.width);
-	assert_eq!(0.0, child_0_layout.height);
+	assert_eq!(0.0, child_0_layout.left());
+	assert_eq!(0.0, child_0_layout.top());
+	assert_eq!(100.0, child_0_layout.width());
+	assert_eq!(0.0, child_0_layout.height());
 
-	assert_eq!(0.0, child_0_child_0_layout.left);
-	assert_eq!(0.0, child_0_child_0_layout.top);
-	assert_eq!(100.0, child_0_child_0_layout.width);
-	assert_eq!(0.0, child_0_child_0_layout.height);
+	assert_eq!(0.0, child_0_child_0_layout.left());
+	assert_eq!(0.0, child_0_child_0_layout.top());
+	assert_eq!(100.0, child_0_child_0_layout.width());
+	assert_eq!(0.0, child_0_child_0_layout.height());
 }

--- a/tests/size_overflow_test.rs
+++ b/tests/size_overflow_test.rs
@@ -31,20 +31,20 @@ fn test_nested_overflowing_child() {
 	let root_child_0_layout = root_child_0.get_layout();
 	let root_child_0_child_0_layout = root_child_0_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, root_child_0_layout.left);
-	assert_eq!(0.0, root_child_0_layout.top);
-	assert_eq!(100.0, root_child_0_layout.width);
-	assert_eq!(200.0, root_child_0_layout.height);
+	assert_eq!(0.0, root_child_0_layout.left());
+	assert_eq!(0.0, root_child_0_layout.top());
+	assert_eq!(100.0, root_child_0_layout.width());
+	assert_eq!(200.0, root_child_0_layout.height());
 
-	assert_eq!(0.0, root_child_0_child_0_layout.left);
-	assert_eq!(0.0, root_child_0_child_0_layout.top);
-	assert_eq!(200.0, root_child_0_child_0_layout.width);
-	assert_eq!(200.0, root_child_0_child_0_layout.height);
+	assert_eq!(0.0, root_child_0_child_0_layout.left());
+	assert_eq!(0.0, root_child_0_child_0_layout.top());
+	assert_eq!(200.0, root_child_0_child_0_layout.width());
+	assert_eq!(200.0, root_child_0_child_0_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
@@ -52,20 +52,20 @@ fn test_nested_overflowing_child() {
 	let root_child_0_layout = root_child_0.get_layout();
 	let root_child_0_child_0_layout = root_child_0_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, root_child_0_layout.left);
-	assert_eq!(0.0, root_child_0_layout.top);
-	assert_eq!(100.0, root_child_0_layout.width);
-	assert_eq!(200.0, root_child_0_layout.height);
+	assert_eq!(0.0, root_child_0_layout.left());
+	assert_eq!(0.0, root_child_0_layout.top());
+	assert_eq!(100.0, root_child_0_layout.width());
+	assert_eq!(200.0, root_child_0_layout.height());
 
-	assert_eq!(-100.0, root_child_0_child_0_layout.left);
-	assert_eq!(0.0, root_child_0_child_0_layout.top);
-	assert_eq!(200.0, root_child_0_child_0_layout.width);
-	assert_eq!(200.0, root_child_0_child_0_layout.height);
+	assert_eq!(-100.0, root_child_0_child_0_layout.left());
+	assert_eq!(0.0, root_child_0_child_0_layout.top());
+	assert_eq!(200.0, root_child_0_child_0_layout.width());
+	assert_eq!(200.0, root_child_0_child_0_layout.height());
 }
 
 #[test]
@@ -100,20 +100,20 @@ fn test_nested_overflowing_child_in_constraint_parent() {
 	let root_child_0_layout = root_child_0.get_layout();
 	let root_child_0_child_0_layout = root_child_0_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, root_child_0_layout.left);
-	assert_eq!(0.0, root_child_0_layout.top);
-	assert_eq!(100.0, root_child_0_layout.width);
-	assert_eq!(100.0, root_child_0_layout.height);
+	assert_eq!(0.0, root_child_0_layout.left());
+	assert_eq!(0.0, root_child_0_layout.top());
+	assert_eq!(100.0, root_child_0_layout.width());
+	assert_eq!(100.0, root_child_0_layout.height());
 
-	assert_eq!(0.0, root_child_0_child_0_layout.left);
-	assert_eq!(0.0, root_child_0_child_0_layout.top);
-	assert_eq!(200.0, root_child_0_child_0_layout.width);
-	assert_eq!(200.0, root_child_0_child_0_layout.height);
+	assert_eq!(0.0, root_child_0_child_0_layout.left());
+	assert_eq!(0.0, root_child_0_child_0_layout.top());
+	assert_eq!(200.0, root_child_0_child_0_layout.width());
+	assert_eq!(200.0, root_child_0_child_0_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
@@ -121,20 +121,20 @@ fn test_nested_overflowing_child_in_constraint_parent() {
 	let root_child_0_layout = root_child_0.get_layout();
 	let root_child_0_child_0_layout = root_child_0_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, root_child_0_layout.left);
-	assert_eq!(0.0, root_child_0_layout.top);
-	assert_eq!(100.0, root_child_0_layout.width);
-	assert_eq!(100.0, root_child_0_layout.height);
+	assert_eq!(0.0, root_child_0_layout.left());
+	assert_eq!(0.0, root_child_0_layout.top());
+	assert_eq!(100.0, root_child_0_layout.width());
+	assert_eq!(100.0, root_child_0_layout.height());
 
-	assert_eq!(-100.0, root_child_0_child_0_layout.left);
-	assert_eq!(0.0, root_child_0_child_0_layout.top);
-	assert_eq!(200.0, root_child_0_child_0_layout.width);
-	assert_eq!(200.0, root_child_0_child_0_layout.height);
+	assert_eq!(-100.0, root_child_0_child_0_layout.left());
+	assert_eq!(0.0, root_child_0_child_0_layout.top());
+	assert_eq!(200.0, root_child_0_child_0_layout.width());
+	assert_eq!(200.0, root_child_0_child_0_layout.height());
 }
 
 #[test]
@@ -168,20 +168,20 @@ fn test_parent_wrap_child_size_overflowing_parent() {
 	let root_child_0_layout = root_child_0.get_layout();
 	let root_child_0_child_0_layout = root_child_0_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, root_child_0_layout.left);
-	assert_eq!(0.0, root_child_0_layout.top);
-	assert_eq!(100.0, root_child_0_layout.width);
-	assert_eq!(200.0, root_child_0_layout.height);
+	assert_eq!(0.0, root_child_0_layout.left());
+	assert_eq!(0.0, root_child_0_layout.top());
+	assert_eq!(100.0, root_child_0_layout.width());
+	assert_eq!(200.0, root_child_0_layout.height());
 
-	assert_eq!(0.0, root_child_0_child_0_layout.left);
-	assert_eq!(0.0, root_child_0_child_0_layout.top);
-	assert_eq!(100.0, root_child_0_child_0_layout.width);
-	assert_eq!(200.0, root_child_0_child_0_layout.height);
+	assert_eq!(0.0, root_child_0_child_0_layout.left());
+	assert_eq!(0.0, root_child_0_child_0_layout.top());
+	assert_eq!(100.0, root_child_0_child_0_layout.width());
+	assert_eq!(200.0, root_child_0_child_0_layout.height());
 
 	root.calculate_layout(Undefined, Undefined, Direction::RTL);
 
@@ -189,18 +189,18 @@ fn test_parent_wrap_child_size_overflowing_parent() {
 	let root_child_0_layout = root_child_0.get_layout();
 	let root_child_0_child_0_layout = root_child_0_child_0.get_layout();
 
-	assert_eq!(0.0, root_layout.left);
-	assert_eq!(0.0, root_layout.top);
-	assert_eq!(100.0, root_layout.width);
-	assert_eq!(100.0, root_layout.height);
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(100.0, root_layout.width());
+	assert_eq!(100.0, root_layout.height());
 
-	assert_eq!(0.0, root_child_0_layout.left);
-	assert_eq!(0.0, root_child_0_layout.top);
-	assert_eq!(100.0, root_child_0_layout.width);
-	assert_eq!(200.0, root_child_0_layout.height);
+	assert_eq!(0.0, root_child_0_layout.left());
+	assert_eq!(0.0, root_child_0_layout.top());
+	assert_eq!(100.0, root_child_0_layout.width());
+	assert_eq!(200.0, root_child_0_layout.height());
 
-	assert_eq!(0.0, root_child_0_child_0_layout.left);
-	assert_eq!(0.0, root_child_0_child_0_layout.top);
-	assert_eq!(100.0, root_child_0_child_0_layout.width);
-	assert_eq!(200.0, root_child_0_child_0_layout.height);
+	assert_eq!(0.0, root_child_0_child_0_layout.left());
+	assert_eq!(0.0, root_child_0_child_0_layout.top());
+	assert_eq!(100.0, root_child_0_child_0_layout.width());
+	assert_eq!(200.0, root_child_0_child_0_layout.height());
 }


### PR DESCRIPTION
Depends on https://github.com/bschwind/yoga-rs/pull/29