### PR TITLE
Guarantee context lifetimes

### DIFF
--- a/tests/context_test.rs
+++ b/tests/context_test.rs
@@ -5,17 +5,21 @@ use std::rc::Rc;
 use yoga::{Context, Direction, MeasureMode, Node, NodeRef, Size, Undefined};
 
 #[test]
+fn test_context_0() {
+	let root = Node::new();
+	assert!(root.get_own_context().is_none());
+	assert!(root.get_own_context_mut().is_none());
+}
+
+#[test]
 fn test_context_1() {
 	let mut root = Node::new();
-	let ref mut context = Context::new("test".to_string());
-	root.set_context(context);
+	root.set_context(Some(Context::new("test".to_string())));
 
-	let retrieved_context = root.get_own_context();
-
-	assert_eq!(
-		context.downcast_ref::<String>().unwrap(),
-		retrieved_context.downcast_ref::<String>().unwrap()
-	);
+	let context = root.get_own_context().unwrap();
+	assert!(context.downcast_ref::<bool>().is_none());
+	assert!(context.downcast_ref::<&str>().is_none());
+	assert_eq!(context.downcast_ref::<String>().unwrap(), "test");
 }
 
 #[test]
@@ -30,7 +34,9 @@ fn test_context_2_safe_check() {
 		_: f32,
 		_: MeasureMode,
 	) -> Size {
-		let context = Node::get_context(&node_ref).downcast_ref::<Bogus>();
+		let context = Node::get_context(&node_ref)
+			.unwrap()
+			.downcast_ref::<Bogus>();
 
 		assert_eq!(context, None);
 
@@ -41,8 +47,8 @@ fn test_context_2_safe_check() {
 	}
 
 	let mut root = Node::new();
-	let ref mut context = Context::new("test".to_string());
-	root.set_context(context);
+	let context = Context::new("test".to_string());
+	root.set_context(Some(context));
 	root.set_measure_func(Some(measure));
 
 	root.calculate_layout(Undefined, Undefined, Direction::LTR);
@@ -65,6 +71,7 @@ fn test_context_2() {
 		_: MeasureMode,
 	) -> Size {
 		let context = Node::get_context(&node_ref)
+			.unwrap()
 			.downcast_ref::<String>()
 			.unwrap();
 
@@ -75,8 +82,8 @@ fn test_context_2() {
 	}
 
 	let mut root = Node::new();
-	let ref mut context = Context::new("test".to_string());
-	root.set_context(context);
+	let context = Context::new("test".to_string());
+	root.set_context(Some(context));
 	root.set_measure_func(Some(measure));
 
 	root.calculate_layout(Undefined, Undefined, Direction::LTR);
@@ -91,14 +98,14 @@ fn test_context_2() {
 
 #[test]
 fn test_context_3() {
-	struct SimpleFont {
+	struct LocalSimpleFont {
 		letter_width: f32,
 		letter_height: f32,
 	}
 
-	struct CustomData {
+	struct LocalCustomData {
 		text: String,
-		font: Rc<RefCell<SimpleFont>>,
+		font: Rc<RefCell<LocalSimpleFont>>,
 	}
 
 	extern "C" fn measure(
@@ -109,7 +116,8 @@ fn test_context_3() {
 		_: MeasureMode,
 	) -> Size {
 		let context = Node::get_context(&node_ref)
-			.downcast_ref::<CustomData>()
+			.unwrap()
+			.downcast_ref::<LocalCustomData>()
 			.unwrap();
 
 		let text = &context.text;
@@ -121,18 +129,18 @@ fn test_context_3() {
 		}
 	}
 
-	let shared_font = Rc::new(RefCell::new(SimpleFont {
+	let shared_font = Rc::new(RefCell::new(LocalSimpleFont {
 		letter_width: 2.0,
 		letter_height: 10.0,
 	}));
 
-	let mut data = Context::new(CustomData {
+	let data = Context::new(LocalCustomData {
 		text: "hello world".to_string(),
 		font: shared_font,
 	});
 
 	let mut root = Node::new();
-	root.set_context(&mut data);
+	root.set_context(Some(data));
 	root.set_measure_func(Some(measure));
 
 	root.calculate_layout(Undefined, Undefined, Direction::LTR);
@@ -143,4 +151,61 @@ fn test_context_3() {
 	assert_eq!(0.0, root_layout.top());
 	assert_eq!(22.0, root_layout.width());
 	assert_eq!(10.0, root_layout.height());
+}
+
+struct ExternalSimpleFont {
+	letter_width: f32,
+	letter_height: f32,
+}
+
+struct ExternalCustomData {
+	text: String,
+	font: Rc<RefCell<ExternalSimpleFont>>,
+}
+
+#[test]
+fn test_context_4() {
+	let shared_font = Rc::new(RefCell::new(ExternalSimpleFont {
+		letter_width: 2.0,
+		letter_height: 10.0,
+	}));
+
+	let data = Context::new(ExternalCustomData {
+		text: "hello world".to_string(),
+		font: shared_font,
+	});
+
+	let mut root = Node::new();
+	root.set_context(Some(data));
+	root.set_measure_func(Some(external_measure));
+
+	root.calculate_layout(Undefined, Undefined, Direction::LTR);
+
+	let root_layout = root.get_layout();
+
+	assert_eq!(0.0, root_layout.left());
+	assert_eq!(0.0, root_layout.top());
+	assert_eq!(22.0, root_layout.width());
+	assert_eq!(10.0, root_layout.height());
+}
+
+extern "C" fn external_measure(
+	node_ref: NodeRef,
+	_: f32,
+	_: MeasureMode,
+	_: f32,
+	_: MeasureMode,
+) -> Size {
+	let context = Node::get_context(&node_ref)
+		.unwrap()
+		.downcast_ref::<ExternalCustomData>()
+		.unwrap();
+
+	let text = &context.text;
+	let font = context.font.borrow();
+
+	Size {
+		width: text.len() as f32 * font.letter_width,
+		height: font.letter_height,
+	}
 }


### PR DESCRIPTION
Hello again :)

Adding support contexts was fun, but the existing implementation had two big problems, that this PR attempts to solve:

1. Calls to `get_context` assumed a `set_context`. This isn't necessarily the case, and although I don't see any sane use of the API to encounter this issue, it was still a problem, which resulted in a crash. To fix this, this patch wraps values in an `Option` for setting and getting contexts.

2. The lifetime of a context wasn't pinned to the lifetime of a `Node`. Contexts going out of scope before a node did (for example, in measure functions which get called *after* context gets dropped) resulted in a crash. To fix this, this patch allows nodes to get ownership of a refcounted context. The refcount cannot go to 0 while a node exists, thus guaranteeing the lifetime. I went for refcounts instead of relying on lifetimes since sharing contexts between nodes might be desirable, in which case simple borrows won't work, and that's what Rc<T> is for.

I've added a bunch of new tests which would have crashed before these changes.