### PR TITLE
Set dirty flag when removing a child node through Node::drop()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -935,10 +935,14 @@ impl Drop for Node {
 		self.set_context(None);
 
 		unsafe {
+			// In the current revision (a20bde8444474e7a34352a78073de23c26e08fc5),
+			// YGNodeFree does not mark the parent as dirty, but YGNodeRemoveChild does. 
+			// TODO remove the following lines when upgrading to a more recent revision of yoga. 
 			let parent = internal::YGNodeGetParent(self.inner_node);
 			if parent != 0 as NodeRef {
 				internal::YGNodeRemoveChild(internal::YGNodeGetParent(self.inner_node), self.inner_node);
 			}
+
 			internal::YGNodeFree(self.inner_node);
 		}
 	}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -935,7 +935,10 @@ impl Drop for Node {
 		self.set_context(None);
 
 		unsafe {
-			// YGNodeFree already orphans all its children
+			let parent = internal::YGNodeGetParent(self.inner_node);
+			if parent != 0 as NodeRef {
+				internal::YGNodeRemoveChild(internal::YGNodeGetParent(self.inner_node), self.inner_node);
+			}
 			internal::YGNodeFree(self.inner_node);
 		}
 	}

--- a/tests/relayout_test.rs
+++ b/tests/relayout_test.rs
@@ -18,3 +18,22 @@ fn test_recalculate_resolved_dimension_onchange() {
 	root.calculate_layout(Undefined, Undefined, Direction::LTR);
 	assert_eq!(0, root_child0.get_layout_height() as i32);
 }
+
+#[test]
+fn test_relayout_on_drop() {
+
+	let mut root = Node::new();
+
+	{
+		let mut root_child0 = Node::new();
+		root_child0.set_min_height(StyleUnit::Point(10.0.into()));
+		root_child0.set_max_height(StyleUnit::Point(10.0.into()));
+		root.insert_child(&mut root_child0, 0);
+		root.calculate_layout(Undefined, Undefined, Direction::LTR);
+		assert_eq!(10, root.get_layout_height() as i32);
+		// root_child0 dropped here
+	}
+
+	root.calculate_layout(Undefined, Undefined, Direction::LTR);
+	assert_eq!(0, root.get_layout_height() as i32);   // fails, should pass
+}


### PR DESCRIPTION
Fixes #41 