### PR TITLE
Use bindgen that fixes codegen for `YGUndefined`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ default = []
 serde_support = ["serde", "serde_derive", "ordered-float/serde"]
 
 [build-dependencies]
-bindgen = "0.71"
+bindgen = "0.72.1"
 cc = "1.2.9"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ default = []
 serde_support = ["serde", "serde_derive", "ordered-float/serde"]
 
 [build-dependencies]
-bindgen = "0.72.1"
+bindgen = { git = "https://github.com/nicoburns/rust-bindgen", rev = "144e2c4f4bb88b445895c08821ab393fcd5a4614" }
 cc = "1.2.9"
 
 [dependencies]

--- a/build.rs
+++ b/build.rs
@@ -115,6 +115,12 @@ fn main() {
     let out_file = out_path.join("bindings.rs");
     bindings.write_to_file(&out_file).expect("Unable to write bindings!");
 
+    // Format file so patch works reliably
+    Command::new("rustfmt")
+        .args([&out_file])
+        .status()
+        .expect("Unable to format bindings");
+
     // Patch bindings because bindgen is incorecctly detected float type
     let buf = read_to_string(&out_file).expect("Unable to read bindings");
     let patched = buf.replace(

--- a/build.rs
+++ b/build.rs
@@ -6,12 +6,7 @@ use bindgen::{
     NonCopyUnionStyle, RustTarget,
 };
 use cc::Build;
-use std::{
-    env,
-    fs::{read_to_string, write},
-    path::PathBuf,
-    process::Command,
-};
+use std::{env, path::PathBuf, process::Command};
 
 #[derive(Debug)]
 struct BindgenCallbacks;
@@ -111,23 +106,11 @@ fn main() {
         .header("src/wrapper.hpp")
         .generate()
         .expect("Unable to generate bindings");
+
+    // Write bindings to file
     let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
     let out_file = out_path.join("bindings.rs");
     bindings.write_to_file(&out_file).expect("Unable to write bindings!");
-
-    // Format file so patch works reliably
-    Command::new("rustfmt")
-        .args([&out_file])
-        .status()
-        .expect("Unable to format bindings");
-
-    // Patch bindings because bindgen is incorecctly detected float type
-    let buf = read_to_string(&out_file).expect("Unable to read bindings");
-    let patched = buf.replace(
-        "pub const YGUndefined: f32 = f64::NAN;",
-        "pub const YGUndefined: f32 = f32::NAN;",
-    );
-    write(&out_file, patched).expect("Unable to write patched bindings");
 
     println!("Bindings written to {}", &out_file.display());
 }


### PR DESCRIPTION
Our hacky string-replacement patch for the generated bindings has started failing (I think due to different formatting causing our string replacement to fail). This PR replaces it with an actual fix in `bindgen`.

Depends on the upstream PR landing:
- https://github.com/rust-lang/rust-bindgen/pull/3300